### PR TITLE
Use git submodule to download pulsar-client-cpp dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,17 @@ MANIFEST
 build
 dist
 *.egg-info
+*.whl
+*.pyd
+
+# CMake files
+CMakeCache.txt
+CMakeFiles
+Makefile
+_pulsar.so
+cmake_install.cmake
+# The documented CMake build directory in the README.md
+build/
+
+# https://github.com/MaskRay/ccls
+.ccls

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 *.egg-info
 *.whl
 *.pyd
+__pycache__/
 
 # CMake files
 CMakeCache.txt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pulsar-client-cpp"]
+	path = pulsar-client-cpp
+	url = https://github.com/apache/pulsar-client-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,84 @@
 # under the License.
 #
 
-INCLUDE_DIRECTORIES("${Boost_INCLUDE_DIRS}" "${PYTHON_INCLUDE_DIRS}")
+project (pulsar-client-python)
+cmake_minimum_required(VERSION 3.12)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_PREFIX_PATH
+    ${CMAKE_PREFIX_PATH}
+    ${CMAKE_SOURCE_DIR}/pulsar-client-cpp/build)
+
+set(PULSAR_CPP_INCLUDE_DIRS
+    ${CMAKE_SOURCE_DIR}/pulsar-client-cpp/include
+    ${CMAKE_SOURCE_DIR}
+)
+
+# Enable this option if the Pulsar C++ client was built with LINK_STATIC=ON
+option(PULASR_CPPLINK_STATIC "Link against static libraries" OFF)
+
+if (NOT PULASR_CPPLINK_STATIC)
+    set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/lib64/)
+    ### This part is to find and keep SSL dynamic libs in RECORD_OPENSSL_SSL_LIBRARY and RECORD_OPENSSL_CRYPTO_LIBRARY
+    ### After find the libs, will unset related cache, and will not affect another same call to find_package.
+    if (APPLE)
+        set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/local/opt/openssl/ /opt/homebrew/opt/openssl)
+    endif ()
+    set(OPENSSL_USE_STATIC_LIBS TRUE)
+
+    find_package(OpenSSL REQUIRED)
+    find_library(CURL_LIBRARIES NAMES libcurl.a curl curl_a libcurl_a)
+    find_library(Protobuf_LIBRARIES NAMES libprotobuf.a libprotobuf)
+    find_library(ZLIB_LIBRARIES REQUIRED NAMES libz.a z zlib)
+    find_library(ZSTD_LIBRARIES NAMES libzstd.a)
+    find_library(SNAPPY_LIBRARIES NAMES libsnappy.a)
+
+    set(COMMON_LIBS
+        ${OPENSSL_CRYPTO_LIBRARY}
+        ${CURL_LIBRARIES}
+        ${OPENSSL_SSL_LIBRARY}
+        ${Protobuf_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+        ${ZSTD_LIBRARIES}
+        ${SNAPPY_LIBRARIES}
+    )
+    message(STATUS "COMMON_LIBS: " ${COMMON_LIBS})
+endif ()
+
+find_library(PULSAR_CPP_LIBRARIES NAMES libpulsar.a)
+if (PULSAR_CPP_LIBRARIES)
+    message(STATUS "Found Pulsar C++ library: " ${PULSAR_CPP_LIBRARIES})
+else ()
+    message(FATAL_ERROR "Failed to find Pulsar C++ library")
+endif ()
+
+find_package(PythonLibs REQUIRED)
+message(STATUS "PYTHON: " ${PYTHONLIBS_VERSION_STRING})
+string(REPLACE "." ";" PYTHONLIBS_VERSION_NO_LIST ${PYTHONLIBS_VERSION_STRING})
+list(GET PYTHONLIBS_VERSION_NO_LIST 0 PYTHONLIBS_VERSION_MAJOR)
+list(GET PYTHONLIBS_VERSION_NO_LIST 1 PYTHONLIBS_VERSION_MINOR)
+set(BOOST_PYTHON_NAME_POSTFIX ${PYTHONLIBS_VERSION_MAJOR}${PYTHONLIBS_VERSION_MINOR})
+# For python3 the lib name is boost_python3
+set(BOOST_PYTHON_NAME_LIST python37;python38;python39;python310;python3;python3-mt;python-py${BOOST_PYTHON_NAME_POSTFIX};python${BOOST_PYTHON_NAME_POSTFIX}-mt;python${BOOST_PYTHON_NAME_POSTFIX})
+
+set(Boost_NO_BOOST_CMAKE ON)
+foreach (BOOST_PYTHON_NAME IN LISTS BOOST_PYTHON_NAME_LIST)
+    find_package(Boost QUIET COMPONENTS ${BOOST_PYTHON_NAME})
+    if (${Boost_FOUND})
+        set(BOOST_PYTHON_NAME_FOUND ${BOOST_PYTHON_NAME})
+        break()
+    endif()
+endforeach()
+
+if (NOT ${Boost_FOUND})
+    message(FATAL_ERROR "Could not find Boost Python library")
+endif ()
+message(STATUS "BOOST_PYTHON_NAME_FOUND: " ${BOOST_PYTHON_NAME_FOUND})
+find_package(Boost REQUIRED COMPONENTS ${BOOST_PYTHON_NAME_FOUND})
+
+include_directories(${PULSAR_CPP_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
 
 ADD_LIBRARY(_pulsar SHARED src/pulsar.cc
                            src/producer.cc
@@ -94,10 +171,10 @@ endif ()
 
 if (APPLE)
     set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
-    target_link_libraries(_pulsar -Wl,-all_load pulsarStatic ${PYTHON_WRAPPER_LIBS} ${COMMON_LIBS} ${ICU_LIBS})
+    target_link_libraries(_pulsar -Wl,-all_load ${PULSAR_CPP_LIBRARIES} ${PYTHON_WRAPPER_LIBS} ${COMMON_LIBS})
 else ()
     if (NOT MSVC)
       set (CMAKE_SHARED_LINKER_FLAGS " -static-libgcc  -static-libstdc++")
     endif()
-    target_link_libraries(_pulsar pulsarStatic ${PYTHON_WRAPPER_LIBS} ${COMMON_LIBS})
+    target_link_libraries(_pulsar ${PULSAR_CPP_LIBRARIES} ${PYTHON_WRAPPER_LIBS} ${COMMON_LIBS})
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,7 @@ set(CMAKE_PREFIX_PATH
     ${CMAKE_PREFIX_PATH}
     ${CMAKE_SOURCE_DIR}/pulsar-client-cpp/build)
 
-set(PULSAR_CPP_INCLUDE_DIRS
-    ${CMAKE_SOURCE_DIR}/pulsar-client-cpp/include
-    ${CMAKE_SOURCE_DIR}
-)
+set(PULSAR_CPP_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/pulsar-client-cpp/include)
 
 # Enable this option if the Pulsar C++ client was built with LINK_STATIC=ON
 option(PULASR_CPPLINK_STATIC "Link against static libraries" OFF)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# Pulsar Python client library
+<!-- TOC depthFrom:2 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+## How to build it from source
+
+Requirements:
+- C++ compiler that supports C++11
+- CMake >= 3.12
+- Boost.Python
+
+There are some other library dependencies (i.e. CMake is able to find the libraries), see the following list:
+- [libcurl](https://curl.se/libcurl/)
+- [OpenSSL](https://www.openssl.org/)
+- [Protocol Buffers](https://github.com/protocolbuffers/protobuf) >= 3
+- [zlib](https://github.com/madler/zlib)
+- [zstd](https://github.com/facebook/zstd)
+- [snappy](https://github.com/google/snappy)
+
+The Python client relies on the C++ client, so we must build the C++ client first.
+
+```bash
+./build-client-cpp.sh
+```
+
+> You can set the `CMAKE_CPP_OPTIONS` environment variable to add your customized CMake options when building the C++ client.
+
+After the C++ client is built successfully, you can build the Python library with CMake.
+
+```bash
+cmake -B build
+cmake --build build
+```
+
+Then we will have `_pulsar.so` under the `build` directory.
+
+To verify it works, you should copy `_pulsar.so` into the project directory. Then run `python3 -c 'import pulsar'` to verify it.

--- a/README.md
+++ b/README.md
@@ -54,4 +54,19 @@ cmake --build build
 
 Then we will have `_pulsar.so` under the `build` directory.
 
-To verify it works, you should copy `_pulsar.so` into the project directory. Then run `python3 -c 'import pulsar'` to verify it.
+To verify it works, you should copy `_pulsar.so` into the project directory. Then run `python3 -c 'import pulsar'` to verify the library has been linked correctly.
+
+After that, you can run `test_consumer.py` and `test_producer.py` against a Pulsar standalone as a simple e2e test. You should see the similar outputs here:
+
+```
+Received message 'hello' id='(1,0,-1,0)'
+Received message 'hello' id='(1,1,-1,0)'
+Received message 'hello' id='(1,2,-1,0)'
+Received message 'hello' id='(1,3,-1,0)'
+Received message 'hello' id='(1,4,-1,0)'
+Received message 'hello' id='(1,5,-1,0)'
+Received message 'hello' id='(1,6,-1,0)'
+Received message 'hello' id='(1,7,-1,0)'
+Received message 'hello' id='(1,8,-1,0)'
+Received message 'hello' id='(1,9,-1,0)'
+```

--- a/build-client-cpp.sh
+++ b/build-client-cpp.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+cd `dirname $0`
+
+git submodule update --init
+pushd pulsar-client-cpp
+cmake -B build \
+    -DBUILD_TESTS=OFF -DBUILD_PERF_TOOLS=OFF \
+    -DBUILD_STATIC_LIB=ON \
+    -DBUILD_DYNAMIC_LIB=OFF \
+    $CMAKE_CPP_OPTIONS
+cmake --build build -j 8
+popd

--- a/src/config.cc
+++ b/src/config.cc
@@ -18,7 +18,7 @@
  */
 #include "utils.h"
 #include <pulsar/ConsoleLoggerFactory.h>
-#include "lib/Utils.h"
+#include "pulsar-client-cpp/lib/Utils.h"
 #include <memory>
 
 template <typename T>

--- a/src/config.cc
+++ b/src/config.cc
@@ -18,7 +18,6 @@
  */
 #include "utils.h"
 #include <pulsar/ConsoleLoggerFactory.h>
-#include "pulsar-client-cpp/lib/Utils.h"
 #include <memory>
 
 template <typename T>

--- a/src/future.h
+++ b/src/future.h
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef LIB_FUTURE_H_
+#define LIB_FUTURE_H_
+
+#include <functional>
+#include <mutex>
+#include <memory>
+#include <condition_variable>
+
+#include <list>
+
+typedef std::unique_lock<std::mutex> Lock;
+
+namespace pulsar {
+
+template <typename Result, typename Type>
+struct InternalState {
+    std::mutex mutex;
+    std::condition_variable condition;
+    Result result;
+    Type value;
+    bool complete;
+
+    std::list<typename std::function<void(Result, const Type&)> > listeners;
+};
+
+template <typename Result, typename Type>
+class Future {
+   public:
+    typedef std::function<void(Result, const Type&)> ListenerCallback;
+
+    Future& addListener(ListenerCallback callback) {
+        InternalState<Result, Type>* state = state_.get();
+        Lock lock(state->mutex);
+
+        if (state->complete) {
+            lock.unlock();
+            callback(state->result, state->value);
+        } else {
+            state->listeners.push_back(callback);
+        }
+
+        return *this;
+    }
+
+    Result get(Type& result) {
+        InternalState<Result, Type>* state = state_.get();
+        Lock lock(state->mutex);
+
+        if (!state->complete) {
+            // Wait for result
+            while (!state->complete) {
+                state->condition.wait(lock);
+            }
+        }
+
+        result = state->value;
+        return state->result;
+    }
+
+    template <typename Duration>
+    bool get(Result& res, Type& value, Duration d) {
+        InternalState<Result, Type>* state = state_.get();
+        Lock lock(state->mutex);
+
+        if (!state->complete) {
+            // Wait for result
+            while (!state->complete) {
+                if (!state->condition.wait_for(lock, d, [&state] { return state->complete; })) {
+                    // Timeout while waiting for the future to complete
+                    return false;
+                }
+            }
+        }
+
+        value = state->value;
+        res = state->result;
+        return true;
+    }
+
+   private:
+    typedef std::shared_ptr<InternalState<Result, Type> > InternalStatePtr;
+    Future(InternalStatePtr state) : state_(state) {}
+
+    std::shared_ptr<InternalState<Result, Type> > state_;
+
+    template <typename U, typename V>
+    friend class Promise;
+};
+
+template <typename Result, typename Type>
+class Promise {
+   public:
+    Promise() : state_(std::make_shared<InternalState<Result, Type> >()) {}
+
+    bool setValue(const Type& value) const {
+        static Result DEFAULT_RESULT;
+        InternalState<Result, Type>* state = state_.get();
+        Lock lock(state->mutex);
+
+        if (state->complete) {
+            return false;
+        }
+
+        state->value = value;
+        state->result = DEFAULT_RESULT;
+        state->complete = true;
+
+        decltype(state->listeners) listeners;
+        listeners.swap(state->listeners);
+
+        lock.unlock();
+
+        for (auto& callback : listeners) {
+            callback(DEFAULT_RESULT, value);
+        }
+
+        state->condition.notify_all();
+        return true;
+    }
+
+    bool setFailed(Result result) const {
+        static Type DEFAULT_VALUE;
+        InternalState<Result, Type>* state = state_.get();
+        Lock lock(state->mutex);
+
+        if (state->complete) {
+            return false;
+        }
+
+        state->result = result;
+        state->complete = true;
+
+        decltype(state->listeners) listeners;
+        listeners.swap(state->listeners);
+
+        lock.unlock();
+
+        for (auto& callback : listeners) {
+            callback(result, DEFAULT_VALUE);
+        }
+
+        state->condition.notify_all();
+        return true;
+    }
+
+    bool isComplete() const {
+        InternalState<Result, Type>* state = state_.get();
+        Lock lock(state->mutex);
+        return state->complete;
+    }
+
+    Future<Result, Type> getFuture() const { return Future<Result, Type>(state_); }
+
+   private:
+    typedef std::function<void(Result, const Type&)> ListenerCallback;
+    std::shared_ptr<InternalState<Result, Type> > state_;
+};
+
+class Void {};
+
+} /* namespace pulsar */
+
+#endif /* LIB_FUTURE_H_ */

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,7 +23,7 @@
 
 #include <pulsar/Client.h>
 #include <pulsar/MessageBatch.h>
-#include <lib/Utils.h>
+#include "pulsar-client-cpp/lib/Utils.h"
 
 using namespace pulsar;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,7 +23,7 @@
 
 #include <pulsar/Client.h>
 #include <pulsar/MessageBatch.h>
-#include "pulsar-client-cpp/lib/Utils.h"
+#include "future.h"
 
 using namespace pulsar;
 
@@ -39,6 +39,29 @@ inline void CHECK_RESULT(Result res) {
         throw PulsarException(res);
     }
 }
+
+struct WaitForCallback {
+    Promise<bool, Result> m_promise;
+
+    WaitForCallback(Promise<bool, Result> promise) : m_promise(promise) {}
+
+    void operator()(Result result) { m_promise.setValue(result); }
+};
+
+template <typename T>
+struct WaitForCallbackValue {
+    Promise<Result, T>& m_promise;
+
+    WaitForCallbackValue(Promise<Result, T>& promise) : m_promise(promise) {}
+
+    void operator()(Result result, const T& value) {
+        if (result == ResultOk) {
+            m_promise.setValue(value);
+        } else {
+            m_promise.setFailed(result);
+        }
+    }
+};
 
 void waitForAsyncResult(std::function<void(ResultCallback)> func);
 


### PR DESCRIPTION
### Modifications
- Add [pulsar-client-cpp](https://github.com/apache/pulsar-client-cpp) as the submodule
- Add `build-client-cpp.sh` to build the Pulsar C++ client.
- Fix the CMakeLists.txt to make Python client build successfully. Instead of linking the `pulsarStatic` target, link to the static library built by `build-client-cpp.sh`.
- Add README to describe how to build Python client.

Currently the Python client uses some C++ headers not exposed (i.e. in the `pulsar-client-cpp/lib` directory). This PR added the `pulsar-client-cpp` path prefix. We should remove these includes in future.