### PR TITLE
Find libpulsarwithdeps.a when LINK_STATIC is ON

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -64,3 +64,25 @@ jobs:
       - name: Stop Pulsar service
         run: ./build-support/pulsar-test-service-stop.sh
 
+  build-static-link:
+    name: Build statically linked Python library
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Install OpenSSL
+        run: sudo apt install libssl-dev
+
+      - name: Install dependencies
+        run: ./build-support/install-dependencies.sh ./deps
+
+      - name: Build Python
+        run: |
+          cmake -B build -DLINK_STATIC=ON -DCMAKE_PREFIX_PATH=$PWD/deps/install -DLINK_OPENSSL=ON
+          cmake --build build -j8
+
+      - name: Verify the extension
+        run: cd build && python3 -c 'import _pulsar'

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -76,6 +76,9 @@ jobs:
       - name: Install OpenSSL
         run: sudo apt install libssl-dev
 
+      - name: Install Pulsar C++ client
+        run: build-support/install-cpp-client.sh
+
       - name: Install dependencies
         run: ./build-support/install-dependencies.sh ./deps
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,15 +24,24 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 option(LINK_STATIC "Link against static libraries" OFF)
 MESSAGE(STATUS "LINK_STATIC:  " ${LINK_STATIC})
 
+# The pre-built C++ client might not link to OpenSSL statically.
+# Enable this option to find OpenSSL when LINK_STATIC is ON.
+option(LINK_OPENSSL "Link against OpenSSL" OFF)
+message(STATUS "LINK_OPENSSL: " ${LINK_OPENSSL})
+
 MESSAGE(STATUS "CMAKE_BUILD_TYPE:  " ${CMAKE_BUILD_TYPE})
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 MESSAGE(STATUS "Threads library: " ${CMAKE_THREAD_LIBS_INIT})
 
 if (LINK_STATIC)
-    find_library(PULSAR_LIBRARY NAMES libpulsar.a)
+    find_library(PULSAR_LIBRARY NAMES libpulsarwithdeps.a)
+    if (LINK_OPENSSL)
+        find_package(OpenSSL REQUIRED)
+        message(STATUS "Found OPENSSL_LIBRARIES: " ${OPENSSL_LIBRARIES})
+    endif ()
 else()
-    find_library(PULSAR_LIBRARY NAMES libpulsar.so)
+    find_library(PULSAR_LIBRARY NAMES pulsar)
 endif()
 message(STATUS "PULSAR_LIBRARY: ${PULSAR_LIBRARY}")
 
@@ -150,12 +159,14 @@ message(STATUS "All libraries: ${PYTHON_WRAPPER_LIBS}")
 if (LINK_STATIC)
     if (APPLE)
         set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
-        target_link_libraries(_pulsar -Wl,-all_load ${PYTHON_WRAPPER_LIBS})
+        target_link_libraries(_pulsar -Wl,-all_load ${PYTHON_WRAPPER_LIBS}
+            "-framework Foundation"
+            "-framework SystemConfiguration")
     else ()
         if (NOT MSVC)
           set (CMAKE_SHARED_LINKER_FLAGS " -static-libgcc  -static-libstdc++")
         endif()
-        target_link_libraries(_pulsar ${PYTHON_WRAPPER_LIBS})
+        target_link_libraries(_pulsar ${PYTHON_WRAPPER_LIBS} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
     endif ()
 else()
     target_link_libraries(_pulsar ${PYTHON_WRAPPER_LIBS})

--- a/build-support/dep-version.py
+++ b/build-support/dep-version.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import yaml, sys
+
+deps = yaml.safe_load(open("dependencies.yaml"))
+print(deps[sys.argv[1]])

--- a/build-support/install-dependencies.sh
+++ b/build-support/install-dependencies.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e -x
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+cd $ROOT_DIR
+
+CACHE_DIR=~/.pulsar-python-deps
+if [[ $# -le 1 ]]; then
+    CACHE_DIR=$(mkdir -p $1 && cd $1 && pwd)
+fi
+PREFIX=$CACHE_DIR/install
+echo "Use $CACHE_DIR to cache dependencies"
+
+python3 -m pip install pyyaml
+
+BOOST_VERSION=$(./build-support/dep-version.py boost)
+mkdir -p $CACHE_DIR
+cd $CACHE_DIR
+
+download() {
+    URL=$1
+    BASENAME=$(basename $URL)
+    if [[ ! -f $BASENAME ]]; then
+        echo "curl -O -L $URL"
+        curl -O -L $URL
+    fi
+    tar xfz $BASENAME
+}
+
+# Install Boost
+BOOST_VERSION_=${BOOST_VERSION//./_}
+DIR=boost_$BOOST_VERSION_
+if [[ ! -f $DIR/.done ]]; then
+    echo "Building Boost $BOOST_VERSION"
+    download https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_}.tar.gz
+    mkdir -p $PREFIX/include
+    pushd $DIR
+        ./bootstrap.sh --with-libraries=python --with-python=python3 --prefix=$PREFIX 2>&1 >/dev/null
+        ./b2 address-model=64 cxxflags="-fPIC" link=static threading=multi -j8 install 2>&1 >/dev/null
+        touch .done
+    popd
+else
+    echo "Using cached Boost $BOOST_VERSION"
+fi

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+boost: 1.80.0


### PR DESCRIPTION
### Motivation

Currently when LINK_STATIC is ON, Python client will still find libpulsar.a, which doesn't include the 3rd party dependencies of C++ client. In this case, we have to find those libraries.

A simple way is to link statically to libpulsarwithdeps.a, which already contains all the dependencies of C++ client.

### Modifications

Find libpulsarwithdeps.a when LINK_STATIC is ON. For macOS, the statically linked libcurl depends on the Foundation and SystemConfiguration frameworks, so the related compile options are added.