### PR TITLE
Support auth param string for Basic authentication

### DIFF
--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -378,6 +378,7 @@ class AuthenticationBasic(Authentication):
         else:
             _check_type(str, username, 'username')
             _check_type(str, password, 'password')
+            _check_type(str, method, 'method')
             self.auth = _pulsar.AuthenticationBasic(username, password, method, '')
 
 class Client:

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -347,18 +347,32 @@ class AuthenticationBasic(Authentication):
     """
     Basic Authentication implementation
     """
-    def __init__(self, username, password):
+    def __init__(self, username=None, password=None, auth_params_string=None):
         """
         Create the Basic authentication provider instance.
 
-        **Args**
+        For example, if you want to create a basic authentication instance whose
+        username is "my-user" and password is "my-pass", there are two ways:
 
-        * `username`: Used to authentication as username
-        * `password`: Used to authentication as password
+        ```
+        auth = AuthenticationBasic('my-user', 'my-pass')
+        auth = AuthenticationBasic(auth_params_string='{"username": "my-user", "password": "my-pass"}')
+        ```
+
+        **Args**
+        * username : str, optional
+        * password : str, optional
+        * auth_params_string : str, optional
+            The JSON presentation of username and password (default is None)
+            If it's not None, the parameters will be ignored
         """
-        _check_type(str, username, 'username')
-        _check_type(str, password, 'password')
-        self.auth = _pulsar.AuthenticationBasic(username, password)
+        if auth_params_string is not None:
+            _check_type(str, auth_params_string, 'auth_params_string')
+            self.auth = _pulsar.AuthenticationBasic('', '', auth_params_string)
+        else:
+            _check_type(str, username, 'username')
+            _check_type(str, password, 'password')
+            self.auth = _pulsar.AuthenticationBasic(username, password, '')
 
 class Client:
     """

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -347,7 +347,7 @@ class AuthenticationBasic(Authentication):
     """
     Basic Authentication implementation
     """
-    def __init__(self, username=None, password=None, auth_params_string=None):
+    def __init__(self, username=None, password=None, method='basic', auth_params_string=None):
         """
         Create the Basic authentication provider instance.
 
@@ -362,17 +362,23 @@ class AuthenticationBasic(Authentication):
         **Args**
         * username : str, optional
         * password : str, optional
+        * method : str, optional
+            The authentication method name (default is 'basic')
         * auth_params_string : str, optional
-            The JSON presentation of username and password (default is None)
-            If it's not None, the parameters will be ignored
+            The JSON presentation of all fields above (default is None)
+            If it's not None, the other parameters will be ignored.
+            Here is an example JSON presentation:
+              {"username": "my-user", "password": "my-pass", "method": "oms3.0"}
+            The `username` and `password` fields are required. If the "method" field is not set,
+            it will be "basic" by default.
         """
         if auth_params_string is not None:
             _check_type(str, auth_params_string, 'auth_params_string')
-            self.auth = _pulsar.AuthenticationBasic('', '', auth_params_string)
+            self.auth = _pulsar.AuthenticationBasic('', '', '', auth_params_string)
         else:
             _check_type(str, username, 'username')
             _check_type(str, password, 'password')
-            self.auth = _pulsar.AuthenticationBasic(username, password, '')
+            self.auth = _pulsar.AuthenticationBasic(username, password, method, '')
 
 class Client:
     """

--- a/src/authentication.cc
+++ b/src/authentication.cc
@@ -91,9 +91,14 @@ struct AuthenticationOauth2Wrapper : public AuthenticationWrapper {
 };
 
 struct AuthenticationBasicWrapper : public AuthenticationWrapper {
-    AuthenticationBasicWrapper(const std::string& username, const std::string& password)
+    AuthenticationBasicWrapper(const std::string& username, const std::string& password,
+                               const std::string& authParamsString)
         : AuthenticationWrapper() {
-        this->auth = AuthBasic::create(username, password);
+        if (authParamsString.empty()) {
+            this->auth = AuthBasic::create(username, password);
+        } else {
+            this->auth = AuthBasic::create(authParamsString);
+        }
     }
 };
 
@@ -115,5 +120,5 @@ void export_authentication() {
                                                                        init<const std::string&>());
 
     class_<AuthenticationBasicWrapper, bases<AuthenticationWrapper> >(
-        "AuthenticationBasic", init<const std::string&, const std::string&>());
+        "AuthenticationBasic", init<const std::string&, const std::string&, const std::string&>());
 }

--- a/src/authentication.cc
+++ b/src/authentication.cc
@@ -92,10 +92,10 @@ struct AuthenticationOauth2Wrapper : public AuthenticationWrapper {
 
 struct AuthenticationBasicWrapper : public AuthenticationWrapper {
     AuthenticationBasicWrapper(const std::string& username, const std::string& password,
-                               const std::string& authParamsString)
+                               const std::string& method, const std::string& authParamsString)
         : AuthenticationWrapper() {
         if (authParamsString.empty()) {
-            this->auth = AuthBasic::create(username, password);
+            this->auth = AuthBasic::create(username, password, method);
         } else {
             this->auth = AuthBasic::create(authParamsString);
         }
@@ -120,5 +120,6 @@ void export_authentication() {
                                                                        init<const std::string&>());
 
     class_<AuthenticationBasicWrapper, bases<AuthenticationWrapper> >(
-        "AuthenticationBasic", init<const std::string&, const std::string&, const std::string&>());
+        "AuthenticationBasic",
+        init<const std::string&, const std::string&, const std::string&, const std::string&>());
 }

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -1301,12 +1301,10 @@ class PulsarTest(TestCase):
         with self.assertRaises(TypeError):
             fun()
 
-    def test_basic_auth(self):
-        username = "admin"
-        password = "123456"
-        client = Client(self.adminUrl, authentication=AuthenticationBasic(username, password))
+    def _test_basic_auth(self, id, auth):
+        client = Client(self.adminUrl, authentication=auth)
 
-        topic = "persistent://private/auth/my-python-topic-basic-auth"
+        topic = "persistent://private/auth/my-python-topic-basic-auth-" + str(id)
         consumer = client.subscribe(topic, "my-sub", consumer_type=ConsumerType.Shared)
         producer = client.create_producer(topic)
         producer.send(b"hello")
@@ -1316,6 +1314,14 @@ class PulsarTest(TestCase):
         self.assertEqual(msg.data(), b"hello")
         client.close()
 
+    def test_basic_auth(self):
+        username = "admin"
+        password = "123456"
+        self._test_basic_auth(0, AuthenticationBasic(username, password))
+        self._test_basic_auth(1, AuthenticationBasic(
+            auth_params_string='{{"username": "{}","password": "{}"}}'.format(username, password)
+        ))
+
     def test_invalid_basic_auth(self):
         username = "invalid"
         password = "123456"
@@ -1323,6 +1329,13 @@ class PulsarTest(TestCase):
         topic = "persistent://private/auth/my-python-topic-invalid-basic-auth"
         with self.assertRaises(pulsar.ConnectError):
             client.subscribe(topic, "my-sub", consumer_type=ConsumerType.Shared)
+        client = Client(self.adminUrl, authentication=AuthenticationBasic(
+            auth_params_string='{{"username": "{}","password": "{}"}}'.format(username, password)
+        ))
+        with self.assertRaises(pulsar.ConnectError):
+            client.subscribe(topic, "my-sub", consumer_type=ConsumerType.Shared)
+        with self.assertRaises(RuntimeError):
+            AuthenticationBasic(auth_params_string='invalid auth params')
 
 if __name__ == "__main__":
     main()

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -1322,6 +1322,20 @@ class PulsarTest(TestCase):
             auth_params_string='{{"username": "{}","password": "{}"}}'.format(username, password)
         ))
 
+    def test_basic_auth_method(self):
+        username = "admin"
+        password = "123456"
+        self._test_basic_auth(2, AuthenticationBasic(username, password, 'basic'))
+        with self.assertRaises(pulsar.AuthorizationError):
+            self._test_basic_auth(3, AuthenticationBasic(username, password, 'unknown'))
+        self._test_basic_auth(4, AuthenticationBasic(
+            auth_params_string='{{"username": "{}","password": "{}", "method": "basic"}}'.format(username, password)
+        ))
+        with self.assertRaises(pulsar.AuthorizationError):
+            self._test_basic_auth(5, AuthenticationBasic(
+                auth_params_string='{{"username": "{}","password": "{}", "method": "unknown"}}'.format(username, password)
+            ))
+
     def test_invalid_basic_auth(self):
         username = "invalid"
         password = "123456"


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/17482 supported basic authentication for Python client, but the `AuthenticationBasic` class accepts two positional arguments as the username and password. It's not good for extension. We should accept an auth param string like `AuthenticationOauth2` so that no changes are needed if the upstream C++ client's implementation changed, like
https://github.com/apache/pulsar-client-cpp/pull/37.

### Modifications

To be compatible with the existing API, change the first two arguments to keyword arguments. Then, add the 3rd keyword argument to represent the auth param string.

### Verifications

`test_basic_auth` and `test_invalid_basic_auth` are extended for this change.