### PR TITLE
Fixed missed version of zlib

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -22,7 +22,7 @@ boost: 1.80.0
 # Only used for MacOS builds
 cmake: 3.24.2
 protobuf: 3.20.0
-zlib: 1.2.12
+zlib: 1.2.13
 zstd: 1.5.2
 snappy: 1.1.9
 openssl: 1.1.1q

--- a/pkg/mac/build-dependencies.sh
+++ b/pkg/mac/build-dependencies.sh
@@ -50,7 +50,7 @@ PREFIX=$CACHE_DIR/install
 ###############################################################################
 if [ ! -f zlib-${ZLIB_VERSION}/.done ]; then
     echo "Building ZLib"
-    curl -O -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
+    curl -O -L https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz
     tar xfz zlib-$ZLIB_VERSION.tar.gz
     pushd zlib-$ZLIB_VERSION
       CFLAGS="-fPIC -O3 -arch arm64 -arch x86_64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" ./configure --prefix=$PREFIX


### PR DESCRIPTION
CI jobs has started failing because a new version of ZLib was released and the old one was removed. 

We need to change the URL to point to the archive so that we won't get in the same situation on next release.