### PR TITLE
Enable building Mac universal2 wheels for Python 3.7

### DIFF
--- a/.github/workflows/ci-build-release-wheels.yaml
+++ b/.github/workflows/ci-build-release-wheels.yaml
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         py:
-          - {version: '3.7', version_long:  '3.7.14'}
+          - {version: '3.7', version_long:  '3.7.15'}
           - {version: '3.8', version_long:  '3.8.13'}
           - {version: '3.9', version_long:  '3.9.14'}
           - {version: '3.10', version_long:  '3.10.7'}

--- a/pkg/mac/build-dependencies.sh
+++ b/pkg/mac/build-dependencies.sh
@@ -70,15 +70,12 @@ if [ ! -f Python-${PYTHON_VERSION_LONG}/.done ]; then
 
   pushd Python-${PYTHON_VERSION_LONG}
       if [ $PYTHON_VERSION = '3.7' ]; then
-          UNIVERSAL_ARCHS='intel-64'
-          PY_CFLAGS=" -arch x86_64"
-      else
-          UNIVERSAL_ARCHS='universal2'
+          patch -p1 < ${ROOT_DIR}/pkg/mac/python-3.7.patch
       fi
 
       CFLAGS="-fPIC -O3 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} -I${PREFIX}/include ${PY_CFLAGS}" \
           LDFLAGS=" ${PY_CFLAGS} -L${PREFIX}/lib" \
-          ./configure --prefix=$PREFIX --enable-shared --enable-universalsdk --with-universal-archs=${UNIVERSAL_ARCHS}
+          ./configure --prefix=$PREFIX --enable-shared --enable-universalsdk --with-universal-archs=universal2
       make -j16
       make install
 

--- a/pkg/mac/build-mac-wheels.sh
+++ b/pkg/mac/build-mac-wheels.sh
@@ -49,10 +49,6 @@ PIP_EXE=$PREFIX/bin/pip3
 
 ARCHS='arm64;x86_64'
 PIP_TAG='universal2'
-if [ $PYTHON_VERSION = '3.7' ]; then
-    ARCHS='x86_64'
-    PIP_TAG=$ARCHS
-fi
 
 cmake . \
         -DCMAKE_OSX_ARCHITECTURES=${ARCHS} \
@@ -67,7 +63,7 @@ cmake . \
         -DBOOST_ROOT=${PREFIX}
 
 make clean
-make -j16 VERBOSE=1
+make -j16
 
 $PY_EXE setup.py bdist_wheel
 

--- a/pkg/mac/python-3.7.patch
+++ b/pkg/mac/python-3.7.patch
@@ -1,0 +1,185 @@
+diff -r -u Python-3.7.15.orig/Lib/_osx_support.py Python-3.7.15/Lib/_osx_support.py
+--- Python-3.7.15.orig/Lib/_osx_support.py	2022-10-10 05:34:53.000000000 -0700
++++ Python-3.7.15/Lib/_osx_support.py	2022-10-14 08:10:34.000000000 -0700
+@@ -491,6 +491,8 @@
+                 machine = 'fat64'
+             elif archs == ('i386', 'ppc', 'ppc64', 'x86_64'):
+                 machine = 'universal'
++            elif archs == ('arm64', 'x86_64'):
++                machine = 'universal2'
+             else:
+                 raise ValueError(
+                    "Don't know machine value for archs=%r" % (archs,))
+diff -r -u Python-3.7.15.orig/Modules/_ctypes/libffi_osx/include/ffi.h Python-3.7.15/Modules/_ctypes/libffi_osx/include/ffi.h
+--- Python-3.7.15.orig/Modules/_ctypes/libffi_osx/include/ffi.h	2022-10-10 05:34:53.000000000 -0700
++++ Python-3.7.15/Modules/_ctypes/libffi_osx/include/ffi.h	2022-10-14 08:54:33.000000000 -0700
+@@ -62,7 +62,8 @@
+ #	elif defined(__ppc__) || defined(__ppc64__)
+ #		define POWERPC_DARWIN
+ #	else
+-#	error "Unsupported MacOS X CPU type"
++/* Temp fix to allow for universal2 to build through */
++#		define X86_DARWIN
+ #	endif
+ #else
+ #error "Unsupported OS type"
+@@ -199,9 +200,9 @@
+ 
+ void
+ ffi_raw_call(
+-/*@dependent@*/	ffi_cif*	cif, 
+-				void		(*fn)(void), 
+-/*@out@*/		void*		rvalue, 
++/*@dependent@*/	ffi_cif*	cif,
++				void		(*fn)(void),
++/*@out@*/		void*		rvalue,
+ /*@dependent@*/	ffi_raw*	avalue);
+ 
+ void
+@@ -225,9 +226,9 @@
+ 	longs and doubles are followed by an empty 64-bit word.	*/
+ void
+ ffi_java_raw_call(
+-/*@dependent@*/	ffi_cif*	cif, 
+-				void		(*fn)(void), 
+-/*@out@*/		void*		rvalue, 
++/*@dependent@*/	ffi_cif*	cif,
++				void		(*fn)(void),
++/*@out@*/		void*		rvalue,
+ /*@dependent@*/	ffi_raw*	avalue);
+ 
+ void
+@@ -272,8 +273,8 @@
+ 	ffi_cif*	cif;
+ 
+ #if !FFI_NATIVE_RAW_API
+-	/*	if this is enabled, then a raw closure has the same layout 
+-		as a regular closure.  We use this to install an intermediate 
++	/*	if this is enabled, then a raw closure has the same layout
++		as a regular closure.  We use this to install an intermediate
+ 		handler to do the transaltion, void** -> ffi_raw*. */
+ 	void	(*translate_args)(ffi_cif*,void*,void**,void*);
+ 	void*	this_closure;
+@@ -303,17 +304,17 @@
+ 
+ ffi_status
+ ffi_prep_cif(
+-/*@out@*/ /*@partial@*/					ffi_cif*		cif, 
++/*@out@*/ /*@partial@*/					ffi_cif*		cif,
+ 										ffi_abi			abi,
+-										unsigned int	nargs, 
+-/*@dependent@*/ /*@out@*/ /*@partial@*/	ffi_type*		rtype, 
++										unsigned int	nargs,
++/*@dependent@*/ /*@out@*/ /*@partial@*/	ffi_type*		rtype,
+ /*@dependent@*/							ffi_type**		atypes);
+ 
+ void
+ ffi_call(
+-/*@dependent@*/	ffi_cif*	cif, 
+-				void		(*fn)(void), 
+-/*@out@*/		void*		rvalue, 
++/*@dependent@*/	ffi_cif*	cif,
++				void		(*fn)(void),
++/*@out@*/		void*		rvalue,
+ /*@dependent@*/	void**		avalue);
+ 
+ /* Useful for eliminating compiler warnings */
+diff -r -u Python-3.7.15.orig/Modules/_ctypes/libffi_osx/include/fficonfig.h Python-3.7.15/Modules/_ctypes/libffi_osx/include/fficonfig.h
+--- Python-3.7.15.orig/Modules/_ctypes/libffi_osx/include/fficonfig.h	2022-10-10 05:34:53.000000000 -0700
++++ Python-3.7.15/Modules/_ctypes/libffi_osx/include/fficonfig.h	2022-10-14 13:19:13.000000000 -0700
+@@ -1,4 +1,4 @@
+-/*	Manually created fficonfig.h for Darwin on PowerPC or Intel 
++/*	Manually created fficonfig.h for Darwin on PowerPC or Intel
+ 
+ 	This file is manually generated to do away with the need for autoconf and
+ 	therefore make it easier to cross-compile and build fat binaries.
+@@ -18,7 +18,7 @@
+ #	define	HAVE_LONG_DOUBLE 1
+ #	define	SIZEOF_LONG_DOUBLE 16
+ 
+-#elif defined(__x86_64__)
++#elif defined(__x86_64__) || defined(__arm64__)
+ #	define	BYTEORDER 1234
+ #	undef	HOST_WORDS_BIG_ENDIAN
+ #	undef	WORDS_BIGENDIAN
+@@ -33,10 +33,10 @@
+ #	define	SIZEOF_DOUBLE 8
+ #	if __GNUC__ >= 4
+ #		define	HAVE_LONG_DOUBLE 1
+-#		define	SIZEOF_LONG_DOUBLE 16 
++#		define	SIZEOF_LONG_DOUBLE 16
+ #	else
+ #		undef	HAVE_LONG_DOUBLE
+-#		define	SIZEOF_LONG_DOUBLE 8 
++#		define	SIZEOF_LONG_DOUBLE 8
+ #	endif
+ 
+ #elif defined(__ppc64__)
+@@ -147,4 +147,4 @@
+ #	else
+ #		define FFI_HIDDEN
+ #	endif
+-#endif
+\ No newline at end of file
++#endif
+diff -r -u Python-3.7.15.orig/Modules/_ctypes/libffi_osx/include/ffitarget.h Python-3.7.15/Modules/_ctypes/libffi_osx/include/ffitarget.h
+--- Python-3.7.15.orig/Modules/_ctypes/libffi_osx/include/ffitarget.h	2022-10-10 05:34:53.000000000 -0700
++++ Python-3.7.15/Modules/_ctypes/libffi_osx/include/ffitarget.h	2022-10-14 09:35:48.000000000 -0700
+@@ -4,10 +4,10 @@
+ 	make building fat binaries harder.
+ */
+ 
+-#if defined(__i386__) || defined(__x86_64__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__arm64__)
+ #include "x86-ffitarget.h"
+ #elif defined(__ppc__) || defined(__ppc64__)
+ #include "ppc-ffitarget.h"
+ #else
+ #error "Unsupported CPU type"
+-#endif
+\ No newline at end of file
++#endif
+diff -r -u Python-3.7.15.orig/Modules/_ctypes/libffi_osx/include/x86-ffitarget.h Python-3.7.15/Modules/_ctypes/libffi_osx/include/x86-ffitarget.h
+--- Python-3.7.15.orig/Modules/_ctypes/libffi_osx/include/x86-ffitarget.h	2022-10-10 05:34:53.000000000 -0700
++++ Python-3.7.15/Modules/_ctypes/libffi_osx/include/x86-ffitarget.h	2022-10-14 11:58:41.000000000 -0700
+@@ -33,7 +33,7 @@
+ #	define X86
+ #endif
+ 
+-#if defined(__x86_64__) 
++#if defined(__x86_64__) || defined(__arm64__)
+ #	ifndef X86_64
+ #		define X86_64
+ #	endif
+@@ -58,7 +58,7 @@
+ #endif
+ 
+ 	/* ---- Intel x86 and AMD x86-64 - */
+-#if !defined(X86_WIN32) && (defined(__i386__) || defined(__x86_64__))
++#if !defined(X86_WIN32) && (defined(__i386__) || defined(__x86_64__) || defined(__arm64__))
+ 	FFI_SYSV,
+ 	FFI_UNIX64,   /* Unix variants all use the same ABI for x86-64  */
+ #	ifdef __i386__
+@@ -85,4 +85,4 @@
+ #	define FFI_NATIVE_RAW_API 1	/* x86 has native raw api support */
+ #endif
+ 
+-#endif	// #ifndef LIBFFI_TARGET_H
+\ No newline at end of file
++#endif	// #ifndef LIBFFI_TARGET_H
+Only in Python-3.7.15: config.log
+diff -r -u Python-3.7.15.orig/configure Python-3.7.15/configure
+--- Python-3.7.15.orig/configure	2022-10-10 05:34:53.000000000 -0700
++++ Python-3.7.15/configure	2022-10-14 08:10:34.000000000 -0700
+@@ -7449,6 +7449,11 @@
+                LIPO_32BIT_FLAGS="-extract ppc7400 -extract i386"
+                ARCH_RUN_32BIT="/usr/bin/arch -i386 -ppc"
+                ;;
++            universal2)
++               UNIVERSAL_ARCH_FLAGS="-arch arm64 -arch x86_64"
++               LIPO_32BIT_FLAGS=""
++               ARCH_RUN_32BIT=""
++               ;;
+             *)
+                as_fn_error $? "proper usage is --with-universal-arch=32-bit|64-bit|all|intel|3-way" "$LINENO" 5
+                ;;


### PR DESCRIPTION
Fixed building Python wheels in `universal2` mode (x86_64 + arm64) for Python 3.7.