### PR TITLE
Support building with the default apt sources on Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -30,7 +30,7 @@ jobs:
 
   unit-tests:
     name: Run unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 120
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,11 @@ message(STATUS "PULSAR_INCLUDE: ${PULSAR_INCLUDE}")
 
 SET(CMAKE_CXX_STANDARD 11)
 
-find_package (Python3 REQUIRED COMPONENTS Development)
+find_package (Python3 COMPONENTS Development)
 MESSAGE(STATUS "PYTHON: " ${Python3_VERSION} " - " ${Python3_INCLUDE_DIRS})
+if (NOT Python3_INCLUDE_DIRS)
+    message(FATAL_ERROR "Cannot find Python")
+endif ()
 
 SET(Boost_USE_STATIC_LIBS   ${LINK_STATIC})
 find_package(Boost REQUIRED COMPONENTS python)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 
 project (pulsar-client-python)
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.12)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 
 option(LINK_STATIC "Link against static libraries" OFF)
@@ -41,12 +41,12 @@ message(STATUS "PULSAR_INCLUDE: ${PULSAR_INCLUDE}")
 
 SET(CMAKE_CXX_STANDARD 11)
 
-find_package (Python3 REQUIRED COMPONENTS Development.Module)
+find_package (Python3 REQUIRED COMPONENTS Development)
 MESSAGE(STATUS "PYTHON: " ${Python3_VERSION} " - " ${Python3_INCLUDE_DIRS})
 
 SET(Boost_USE_STATIC_LIBS   ${LINK_STATIC})
-find_package(Boost REQUIRED COMPONENTS python3)
-MESSAGE(STATUS "Boost Python3: " ${Boost_PYTHON3_LIBRARY})
+find_package(Boost REQUIRED COMPONENTS python)
+MESSAGE(STATUS "Boost Python: " ${Boost_PYTHON_LIBRARY})
 MESSAGE(STATUS "Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")
 
 ########################################################################################################################
@@ -81,7 +81,7 @@ endif()
 
 # Try all possible boost-python variable namings
 set(PYTHON_WRAPPER_LIBS ${PULSAR_LIBRARY}
-                        ${Boost_PYTHON3_LIBRARY})
+                        ${Boost_PYTHON_LIBRARY})
 
 message(STATUS "All libraries: ${PYTHON_WRAPPER_LIBS}")
 


### PR DESCRIPTION
### Motivation

Currently the Python client cannot be built with the default apt sources on Ubuntu 20.04, whose default CMake version is 3.16. However, even after I installed CMake 3.24 on Ubuntu 20.04, CMake would still fail to find Boost.Python.

### Modifications

To fix the Boost.Python not found issue, find the `Python` component instead of `Python3` when finding Boost.

In addition, when finding Python3, find the `Development` component instead of the `Development.Module`, which is a sub-component of `Development`. See
https://cmake.org/cmake/help/latest/module/FindPython3.html.

After that, the minimum required CMake version becomes back to 3.12 from 3.18, which was upgraded in
https://github.com/apache/pulsar-client-python/pull/11.