### PR TITLE
fix: make sure that the fallback avro class has the signature as fastravro's

### DIFF
--- a/pulsar/schema/schema_avro.py
+++ b/pulsar/schema/schema_avro.py
@@ -85,7 +85,7 @@ if HAS_AVRO:
 
 else:
     class AvroSchema(Schema):
-        def __init__(self, _record_cls, _schema_definition):
+        def __init__(self, _record_cls, _schema_definition=None):
             raise Exception("Avro library support was not found. Make sure to install Pulsar client " +
                             "with Avro support: pip3 install 'pulsar-client[avro]'")
 


### PR DESCRIPTION
This makes sure that the user get the information about avro support not being installed instead of a TypeError if the schema defitnition is not supplied
