### PR TITLE
Upgrade Pulsar C++ client to 3.1.0

### DIFF
--- a/build-support/dep-url.sh
+++ b/build-support/dep-url.sh
@@ -23,8 +23,7 @@ pulsar_cpp_base_url() {
     exit 1
   fi
   VERSION=$1
-  # TODO: use official release url from https://archive.apache.org/
-  echo "https://dist.apache.org/repos/dist/dev/pulsar/pulsar-client-cpp/pulsar-client-cpp-${VERSION}-candidate-3"
+  echo "https://archive.apache.org/dist/pulsar/pulsar-client-cpp-${VERSION}"
 }
 
 download_dependency() {


### PR DESCRIPTION
After this PR, we can start the first Python client release.