### PR TITLE
#66: Add Human-readable description of MessageId object

### DIFF
--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -102,6 +102,12 @@ class MessageId:
         """
         return self._msg_id.serialize()
 
+    def __str__(self):
+        return "MessageId instance with entry_id %s and ledger_id %s" % (str(self.entry_id), str(self.ledger_id))
+
+    def __repr__(self):
+        return "MessageId instance with entry_id %s and ledger_id %s" % (str(self.entry_id), str(self.ledger_id))
+
     @staticmethod
     def deserialize(message_id_bytes):
         """

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -102,12 +102,6 @@ class MessageId:
         """
         return self._msg_id.serialize()
 
-    def __str__(self):
-        return "MessageId instance with entry_id %s and ledger_id %s" % (str(self.entry_id), str(self.ledger_id))
-
-    def __repr__(self):
-        return "MessageId instance with entry_id %s and ledger_id %s" % (str(self.entry_id), str(self.ledger_id))
-
     @staticmethod
     def deserialize(message_id_bytes):
         """

--- a/src/message.cc
+++ b/src/message.cc
@@ -55,6 +55,12 @@ void export_message(py::module_& m) {
                  oss << msgId;
                  return oss.str();
              })
+        .def("__repr__",
+             [](const MessageId& msgId) {
+                 std::ostringstream oss;
+                 oss << msgId;
+                 return oss.str();
+             })
         .def("__eq__", &MessageId::operator==)
         .def("__ne__", &MessageId::operator!=)
         .def("__le__", &MessageId::operator<=)


### PR DESCRIPTION
@BewareMyPower sorry this took so long, got distracted by some other things. I didn't realize this was already implemented in the C++ client .... at least if i'm not crazy :) So basically I just pulled a binding (same as the __str__ binding) for __repr__, and now the MessageId object looks like the following. Is this sufficient for purposes of this task?
<img width="445" alt="Screenshot 2023-02-14 at 12 40 20 PM" src="https://user-images.githubusercontent.com/700235/218841335-db52d0ed-98a0-4d60-a412-aca338d0c0dd.png">
