### PR TITLE
Issue #37 : Allow passing pulsar.MessageId instance to create_reader()

### DIFF
--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -55,7 +55,7 @@ from pulsar.exceptions import *
 from pulsar.functions.function import Function
 from pulsar.functions.context import Context
 from pulsar.functions.serde import SerDe, IdentitySerDe, PickleSerDe
-from pulsar import schema, MessageId
+from pulsar import schema
 _schema = schema
 
 import re

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -55,7 +55,7 @@ from pulsar.exceptions import *
 from pulsar.functions.function import Function
 from pulsar.functions.context import Context
 from pulsar.functions.serde import SerDe, IdentitySerDe, PickleSerDe
-from pulsar import schema
+from pulsar import schema, MessageId
 _schema = schema
 
 import re
@@ -882,6 +882,11 @@ class Client:
             Symmetric encryption class implementation, configuring public key encryption messages for the producer
             and private key decryption messages for the consumer
         """
+        
+        # If a pulsar.MessageId object is passed, access the _pulsar.MessageId object
+        if isinstance(message_id, MessageId):
+            message_id = message_id._msg_id
+
         _check_type(str, topic, 'topic')
         _check_type(_pulsar.MessageId, start_message_id, 'start_message_id')
         _check_type(_schema.Schema, schema, 'schema')

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -884,8 +884,8 @@ class Client:
         """
         
         # If a pulsar.MessageId object is passed, access the _pulsar.MessageId object
-        if isinstance(message_id, MessageId):
-            message_id = message_id._msg_id
+        if isinstance(start_message_id, MessageId):
+            start_message_id = start_message_id._msg_id
 
         _check_type(str, topic, 'topic')
         _check_type(_pulsar.MessageId, start_message_id, 'start_message_id')


### PR DESCRIPTION
This does a simple check to see whether the object passed to create_reader() is a Python MessageId object - if so, it accesses the _pulsar.MessageId object that's a property before proceeding with the relevant checks and routine.