### PR TITLE
[Enhancement/Feature Issue #47] Added support for KeySharedPolicy for the consumer when in KeyShared mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ wheelhouse
 vcpkg_installed/
 *.pyd
 *.lib
+
+
+lib_pulsar.so
+tests/test.log
+.tests-container-id.txt
+

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -1451,32 +1451,32 @@ class ConsumerKeySharedPolicy:
             raise ValueError("When using key_shared_mode = KeySharedMode.Sticky you must also provide sticky_ranges")
 
         self._policy = KeySharedPolicy()
-        self._policy.setKeySharedMode(key_shared_mode)
-        self._policy.setAllowOutOfOrderDelivery(allow_out_of_order_delivery)
+        self._policy.set_key_shared_mode(key_shared_mode)
+        self._policy.set_allow_out_of_order_delivery(allow_out_of_order_delivery)
 
         if sticky_ranges is not None:
-            self._policy.setStickyRanges(sticky_ranges)
+            self._policy.set_sticky_ranges(sticky_ranges)
 
     @property
     def key_shared_mode(self) -> KeySharedMode:
         """
         Returns the key shared mode
         """
-        return self._policy.getKeySharedMode()
+        return self._policy.get_key_shared_mode()
 
     @property
     def allow_out_of_order_delivery(self) -> bool:
         """
         Returns whether out of order delivery is enabled
         """
-        return self._policy.isAllowOutOfOrderDelivery()
+        return self._policy.is_allow_out_of_order_delivery()
 
     @property
     def sticky_ranges(self) -> List[Tuple[int, int]]:
         """
         Returns the actual sticky ranges
         """
-        return self._policy.getStickyRanges()
+        return self._policy.get_sticky_ranges()
 
     def policy(self):
         """

--- a/src/config.cc
+++ b/src/config.cc
@@ -120,20 +120,17 @@ static ClientConfiguration& ClientConfiguration_setFileLogger(ClientConfiguratio
     return conf;
 }
 
-template <typename... Args>
-using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
-
 void export_config(py::module_& m) {
     using namespace py;
 
     class_<KeySharedPolicy, std::shared_ptr<KeySharedPolicy>>(m, "KeySharedPolicy")
         .def(init<>())
-        .def("setKeySharedMode", &KeySharedPolicy::setKeySharedMode, return_value_policy::reference)
-        .def("getKeySharedMode", &KeySharedPolicy::getKeySharedMode)
-        .def("setAllowOutOfOrderDelivery", &KeySharedPolicy::setAllowOutOfOrderDelivery, return_value_policy::reference)
-        .def("isAllowOutOfOrderDelivery", &KeySharedPolicy::isAllowOutOfOrderDelivery)
-        .def("setStickyRanges", overload_cast_<StickyRanges>()(&KeySharedPolicy::setStickyRanges), return_value_policy::reference)
-        .def("getStickyRanges", &KeySharedPolicy::getStickyRanges);
+        .def("set_key_shared_mode", &KeySharedPolicy::setKeySharedMode, return_value_policy::reference)
+        .def("get_key_shared_mode", &KeySharedPolicy::getKeySharedMode)
+        .def("set_allow_out_of_order_delivery", &KeySharedPolicy::setAllowOutOfOrderDelivery, return_value_policy::reference)
+        .def("is_allow_out_of_order_delivery", &KeySharedPolicy::isAllowOutOfOrderDelivery)
+        .def("set_sticky_ranges", static_cast<KeySharedPolicy& (KeySharedPolicy::*)(const StickyRanges&)>(&KeySharedPolicy::setStickyRanges), return_value_policy::reference)
+        .def("get_sticky_ranges", &KeySharedPolicy::getStickyRanges);
 
     class_<CryptoKeyReader, std::shared_ptr<CryptoKeyReader>>(m, "AbstractCryptoKeyReader")
         .def("getPublicKey", &CryptoKeyReader::getPublicKey)

--- a/src/enums.cc
+++ b/src/enums.cc
@@ -20,6 +20,7 @@
 #include <pulsar/CompressionType.h>
 #include <pulsar/ConsumerConfiguration.h>
 #include <pulsar/ProducerConfiguration.h>
+#include <pulsar/KeySharedPolicy.h>
 #include <pybind11/pybind11.h>
 
 using namespace pulsar;
@@ -27,6 +28,10 @@ namespace py = pybind11;
 
 void export_enums(py::module_& m) {
     using namespace py;
+
+    enum_<KeySharedMode>(m, "KeySharedMode")
+        .value("AutoSplit", AUTO_SPLIT)
+        .value("Sticky", STICKY);
 
     enum_<ProducerConfiguration::PartitionsRoutingMode>(m, "PartitionsRoutingMode")
         .value("UseSinglePartition", ProducerConfiguration::UseSinglePartition)

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -1490,7 +1490,6 @@ class PulsarTest(TestCase):
             key_shared_mode=pulsar.KeySharedMode.AutoSplit,
             allow_out_of_order_delivery=True,
         )
-        
         consumer = client.subscribe(topic, "my-sub", consumer_type=ConsumerType.KeyShared, consumer_name = 'con-1',
                                     start_message_id_inclusive=True, key_shared_policy=consumer_key_shared_policy)
         consumer2 = client.subscribe(topic, "my-sub", consumer_type=ConsumerType.KeyShared, consumer_name = 'con-2',

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -32,6 +32,8 @@ from pulsar import (
     MessageId,
     CompressionType,
     ConsumerType,
+    KeySharedMode,
+    ConsumerKeySharedPolicy,
     PartitionsRoutingMode,
     AuthenticationBasic,
     AuthenticationTLS,
@@ -1437,6 +1439,135 @@ class PulsarTest(TestCase):
         producer.flush()
         client.close()
 
+    def test_keyshare_policy(self):
+        with self.assertRaises(ValueError):
+            # Raise error because sticky ranges are not provided.
+            pulsar.ConsumerKeySharedPolicy(
+                key_shared_mode=pulsar.KeySharedMode.Sticky,
+                allow_out_of_order_delivery=False,
+            )
+
+        expected_key_shared_mode = pulsar.KeySharedMode.Sticky
+        expected_allow_out_of_order_delivery = True
+        expected_sticky_ranges = [(0, 100), (101,200)]
+        consumer_key_shared_policy = pulsar.ConsumerKeySharedPolicy(
+            key_shared_mode=expected_key_shared_mode,
+            allow_out_of_order_delivery=expected_allow_out_of_order_delivery,
+            sticky_ranges=expected_sticky_ranges
+        )
+
+        self.assertEqual(consumer_key_shared_policy.key_shared_mode, expected_key_shared_mode)
+        self.assertEqual(consumer_key_shared_policy.allow_out_of_order_delivery, expected_allow_out_of_order_delivery)
+        self.assertEqual(consumer_key_shared_policy.sticky_ranges, expected_sticky_ranges)
+
+    def test_keyshared_invalid_sticky_ranges(self):
+        client = Client(self.serviceUrl)
+        topic = "my-python-topic-keyshare-invalid-" + str(time.time())
+        with self.assertRaises(ValueError):
+            consumer_key_shared_policy = pulsar.ConsumerKeySharedPolicy(
+                key_shared_mode=pulsar.KeySharedMode.Sticky,
+                allow_out_of_order_delivery=False,
+                sticky_ranges=[(0,65536)]
+            )
+            client.subscribe(topic, "my-sub", consumer_type=ConsumerType.KeyShared,
+                             start_message_id_inclusive=True,
+                             key_shared_policy=consumer_key_shared_policy)
+
+        with self.assertRaises(ValueError):
+            consumer_key_shared_policy = pulsar.ConsumerKeySharedPolicy(
+                key_shared_mode=pulsar.KeySharedMode.Sticky,
+                allow_out_of_order_delivery=False,
+                sticky_ranges=[(0, 100), (50, 150)]
+            )
+            client.subscribe(topic, "my-sub", consumer_type=ConsumerType.KeyShared,
+                             start_message_id_inclusive=True,
+                             key_shared_policy=consumer_key_shared_policy)
+
+
+    def test_keyshared_autosplit(self):
+        client = Client(self.serviceUrl)
+        topic = "my-python-topic-keyshare-autosplit-" + str(time.time())
+        consumer_key_shared_policy = pulsar.ConsumerKeySharedPolicy(
+            key_shared_mode=pulsar.KeySharedMode.AutoSplit,
+            allow_out_of_order_delivery=True,
+        )
+        
+        consumer = client.subscribe(topic, "my-sub", consumer_type=ConsumerType.KeyShared, consumer_name = 'con-1',
+                                    start_message_id_inclusive=True, key_shared_policy=consumer_key_shared_policy)
+        consumer2 = client.subscribe(topic, "my-sub", consumer_type=ConsumerType.KeyShared, consumer_name = 'con-2',
+                                    start_message_id_inclusive=True, key_shared_policy=consumer_key_shared_policy)
+        producer = client.create_producer(topic)
+
+        for i in range(10):
+            if i > 0:
+                time.sleep(0.02)
+            producer.send(b"hello-%d" % i)
+
+        msgs = []
+        while True:
+            try:
+                msg = consumer.receive(100)
+            except pulsar.Timeout:
+                break
+            msgs.append(msgs)
+            consumer.acknowledge(msg)
+
+        while True:
+            try:
+                msg = consumer2.receive(100)
+            except pulsar.Timeout:
+                break
+            msgs.append(msgs)
+            consumer2.acknowledge(msg)
+
+        self.assertEqual(len(msgs), 10)
+        client.close()
+
+    def test_sticky_autosplit(self):
+        client = Client(self.serviceUrl)
+        topic = "my-python-topic-keyshare-sticky-" + str(time.time())
+        consumer_key_shared_policy = pulsar.ConsumerKeySharedPolicy(
+            key_shared_mode=pulsar.KeySharedMode.Sticky,
+            allow_out_of_order_delivery=True,
+            sticky_ranges=[(0,30000)],
+        )
+
+        consumer = client.subscribe(topic, "my-sub", consumer_type=ConsumerType.KeyShared, consumer_name='con-1',
+                                    start_message_id_inclusive=True, key_shared_policy=consumer_key_shared_policy)
+
+        consumer2_key_shared_policy = pulsar.ConsumerKeySharedPolicy(
+            key_shared_mode=pulsar.KeySharedMode.Sticky,
+            allow_out_of_order_delivery=True,
+            sticky_ranges=[(30001, 65535)],
+        )
+        consumer2 = client.subscribe(topic, "my-sub", consumer_type=ConsumerType.KeyShared, consumer_name='con-2',
+                                     start_message_id_inclusive=True, key_shared_policy=consumer2_key_shared_policy)
+        producer = client.create_producer(topic)
+
+        for i in range(10):
+            if i > 0:
+                time.sleep(0.02)
+            producer.send(b"hello-%d" % i)
+
+        msgs = []
+        while True:
+            try:
+                msg = consumer.receive(100)
+            except pulsar.Timeout:
+                break
+            msgs.append(msgs)
+            consumer.acknowledge(msg)
+
+        while True:
+            try:
+                msg = consumer2.receive(100)
+            except pulsar.Timeout:
+                break
+            msgs.append(msgs)
+            consumer2.acknowledge(msg)
+
+        self.assertEqual(len(msgs), 10)
+        client.close()
 
 if __name__ == "__main__":
     main()

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -1507,7 +1507,7 @@ class PulsarTest(TestCase):
                 msg = consumer.receive(100)
             except pulsar.Timeout:
                 break
-            msgs.append(msgs)
+            msgs.append(msg)
             consumer.acknowledge(msg)
 
         while True:
@@ -1515,7 +1515,7 @@ class PulsarTest(TestCase):
                 msg = consumer2.receive(100)
             except pulsar.Timeout:
                 break
-            msgs.append(msgs)
+            msgs.append(msg)
             consumer2.acknowledge(msg)
 
         self.assertEqual(len(msgs), 10)
@@ -1553,7 +1553,7 @@ class PulsarTest(TestCase):
                 msg = consumer.receive(100)
             except pulsar.Timeout:
                 break
-            msgs.append(msgs)
+            msgs.append(msg)
             consumer.acknowledge(msg)
 
         while True:
@@ -1561,7 +1561,7 @@ class PulsarTest(TestCase):
                 msg = consumer2.receive(100)
             except pulsar.Timeout:
                 break
-            msgs.append(msgs)
+            msgs.append(msg)
             consumer2.acknowledge(msg)
 
         self.assertEqual(len(msgs), 10)


### PR DESCRIPTION
### Motivation
The pulsar python client lacks support for defining KeyShared behaviour like out of order message delivery and sticky-hash, auto-hash for consumers in KeyShared mode. This PR adds full support. The user can now provide a KeySharedPolicy when starting a consumer with client.subscribe() #47 

The ConsumerConfiguration::KeySharedPolicy and related setter/getter are now exposed to the Python client in this PR.

### Modifications

- Added pybind11 enum for KeySharedMode in src/enums.cc.
- Added pybind11 class for KeySharedPolicy in src/config.cc.
- Modified pybind11 class for ConsumerConfiguration and added function to set KeySharedPolicy and function to read KeySharedPolicy.
- Added KeySharedPolicy wrapper to pulsar/__init__.py. This wrapper handles KeySharedPolicy initialization and does some value validation.
- Added the key_shared_policy parameter to client.subscribe(), some validation, and adding to the config in pulsar/__init__.py.
- Added 4 new tests to test the new KeySharedPolicy functionality to tests/pulsar_test.py

In order to add this functionality I also had to modify the C++ client slightly. The setter function for setting the sticky ranges in the C++ client takes a parameter of the type std::initializer_list<StickyRange> as seen here https://github.com/apache/pulsar-client-cpp/blob/86d66bdb09bdb596a2a5c25b0a09f3d0182d683e/include/pulsar/KeySharedPolicy.h#L99. But std::initializer_list types are not supported and probably won't ever be supported by pybind11. See https://github.com/pybind/pybind11/issues/1302#issuecomment-369090893. So I added an overloaded setter function that takes a parameter of the type  std::vector<StickyRange>. This modification enables us to have python bindings for KeySharedPolicy. I have submitted a PR to the C++ client here https://github.com/apache/pulsar-client-cpp/pull/242. 

This PR won't work until that referenced C++ client PR is merged. 


### Verifying this change
Added 4 new unit tests. Ran them to ensure they pass. 

### Documentation
Added documentation in the form of comments and docstrings to the new classes and parameters that were added.