### PR TITLE
Upgrade fastavro to 1.7.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ extras_require["functions"] = sorted(
 # avro dependencies
 extras_require["avro"] = sorted(
     {
-      "fastavro==0.24.0"
+      "fastavro==1.7.3"
     }
 )
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-python/issues/67

This PR fixes the client cannot be installed with `[avro]`. Take Python 3.11 on Windows as example:

```PowerShell
D:\> py -m pip install 'pulsar_client-3.2.0a1-cp311-cp311-win_amd64.whl[avro]'
Processing d:\pulsar_client-3.2.0a1-cp311-cp311-win_amd64.whl
Requirement already satisfied: certifi in c:\users\xuyunze\appdata\local\programs\python\python311\lib\site-packages (from pulsar-client==3.2.0a1) (2022.12.7)
Collecting fastavro==1.7.3
  Using cached fastavro-1.7.3-cp311-cp311-win_amd64.whl (406 kB)
pulsar-client is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
Installing collected packages: fastavro
Successfully installed fastavro-1.7.3

[notice] A new release of pip is available: 23.0.1 -> 23.1
[notice] To update, run: python.exe -m pip install --upgrade pip
```

TODO: fix the client cannot be installed with `[all]`.