### PR TITLE
Update to bookkeeper client 4.16.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,8 @@ extras_require = {}
 extras_require["functions"] = sorted(
     {
       "protobuf>=3.6.1,<=3.20.3",
-      "grpcio<1.28,>=1.8.2",
-      "apache-bookkeeper-client>=4.9.2",
+      "grpcio>=1.8.2",
+      "apache-bookkeeper-client>=4.16.1",
       "prometheus_client",
       "ratelimit"
     }


### PR DESCRIPTION
The new BK client is now working with newer version of Grpc, so we can upgrade and use Grpc >1.37 which comes with pre-packaged binaries.