### PR TITLE
Bump the C++ client to 3.2.0

### DIFF
--- a/build-support/dep-url.sh
+++ b/build-support/dep-url.sh
@@ -23,7 +23,7 @@ pulsar_cpp_base_url() {
     exit 1
   fi
   VERSION=$1
-  echo "https://dist.apache.org/repos/dist/release/pulsar/pulsar-client-cpp-${VERSION}"
+  echo "https://archive.apache.org/dist/pulsar/pulsar-client-cpp-${VERSION}"
 }
 
 download_dependency() {

--- a/build-support/dep-url.sh
+++ b/build-support/dep-url.sh
@@ -23,7 +23,7 @@ pulsar_cpp_base_url() {
     exit 1
   fi
   VERSION=$1
-  echo "https://archive.apache.org/dist/pulsar/pulsar-client-cpp-${VERSION}"
+  echo "https://dist.apache.org/repos/dist/release/pulsar/pulsar-client-cpp-${VERSION}"
 }
 
 download_dependency() {

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -18,7 +18,7 @@
 #
 
 cmake: 3.24.2
-pulsar-cpp: 3.1.2
+pulsar-cpp: 3.2.0
 pybind11: 2.10.1
 boost: 1.80.0
 protobuf: 3.20.0


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-python/issues/116

https://github.com/apache/pulsar-client-cpp/pull/266 is included in the C++ client 3.2.0 so that #116 will be fixed.