### PR TITLE
Fetch writer schema to decode Avro messages

### DIFF
--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -127,7 +127,7 @@ class Message:
         """
         Returns object with the de-serialized version of the message content
         """
-        return self._schema.decode(self._message.data())
+        return self._schema.decode_message(self._message)
 
     def properties(self):
         """
@@ -812,6 +812,7 @@ class Client:
 
         c._client = self
         c._schema = schema
+        c._schema.attach_client(self._client)
         self._consumers.append(c)
         return c
 
@@ -913,6 +914,7 @@ class Client:
         c._reader = self._client.create_reader(topic, start_message_id, conf)
         c._client = self
         c._schema = schema
+        c._schema.attach_client(self._client)
         self._consumers.append(c)
         return c
 

--- a/pulsar/schema/schema.py
+++ b/pulsar/schema/schema.py
@@ -38,8 +38,14 @@ class Schema(object):
     def decode(self, data):
         pass
 
+    def decode_message(self, msg: _pulsar.Message):
+        return self.decode(msg.data())
+
     def schema_info(self):
         return self._schema_info
+
+    def attach_client(self, client: _pulsar.Client):
+        self._client = client
 
     def _validate_object_type(self, obj):
         if not isinstance(obj, self._record_cls):

--- a/src/client.cc
+++ b/src/client.cc
@@ -58,6 +58,12 @@ std::vector<std::string> Client_getTopicPartitions(Client& client, const std::st
         [&](GetPartitionsCallback callback) { client.getPartitionsForTopicAsync(topic, callback); });
 }
 
+SchemaInfo Client_getSchemaInfo(Client& client, const std::string& topic, int64_t version) {
+    return waitForAsyncValue<SchemaInfo>([&](std::function<void(Result, const SchemaInfo&)> callback) {
+        client.getSchemaInfoAsync(topic, version, callback);
+    });
+}
+
 void Client_close(Client& client) {
     waitForAsyncResult([&](ResultCallback callback) { client.closeAsync(callback); });
 }
@@ -71,6 +77,7 @@ void export_client(py::module_& m) {
         .def("subscribe_pattern", &Client_subscribe_pattern)
         .def("create_reader", &Client_createReader)
         .def("get_topic_partitions", &Client_getTopicPartitions)
+        .def("get_schema_info", &Client_getSchemaInfo)
         .def("close", &Client_close)
         .def("shutdown", &Client::shutdown);
 }

--- a/src/message.cc
+++ b/src/message.cc
@@ -98,6 +98,7 @@ void export_message(py::module_& m) {
              })
         .def("topic_name", &Message::getTopicName, return_value_policy::copy)
         .def("redelivery_count", &Message::getRedeliveryCount)
+        .def("int_schema_version", &Message::getLongSchemaVersion)
         .def("schema_version", &Message::getSchemaVersion, return_value_policy::copy);
 
     MessageBatch& (MessageBatch::*MessageBatchParseFromString)(const std::string& payload,


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-python/issues/108

### Motivation

Currently the Python client uses the reader schema, which is the schema of the consumer, to decode Avro messages. However, when the writer schema is different from the reader schema, the decode will fail.

### Modifications

Add `attach_client` method to `Schema` and call it when creating consumers and readers. This method stores a reference to a `_pulsar.Client` instance, which leverages the C++ APIs added in https://github.com/apache/pulsar-client-cpp/pull/257 to fetch schema info. The `AvroSchema` class fetches and caches the writer schema if it is not cached, then use both the writer schema and reader schema to decode messages.

Add `test_schema_evolve` to test consumers or readers can decode any message whose writer schema is different with the reader schema.