### PR TITLE
Release the GIL before any call to async methods

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -49,10 +49,14 @@ inline T waitForAsyncValue(std::function<void(std::function<void(Result, const T
     auto resultPromise = std::make_shared<std::promise<Result>>();
     auto valuePromise = std::make_shared<std::promise<T>>();
 
-    func([resultPromise, valuePromise](Result result, const T& value) {
-        valuePromise->set_value(value);
-        resultPromise->set_value(result);
-    });
+    {
+        py::gil_scoped_release release;
+
+        func([resultPromise, valuePromise](Result result, const T& value) {
+            valuePromise->set_value(value);
+            resultPromise->set_value(result);
+        });
+    }
 
     internal::waitForResult(*resultPromise);
     return valuePromise->get_future().get();


### PR DESCRIPTION
Fix #122 

When call an async method on Pulsar C++ client, we need to be releasing the GIL to avoid a deadlock between that and the producer lock.