### PR TITLE
Converted usages of Py_BEGIN_ALLOW_THREADS

### DIFF
--- a/src/consumer.cc
+++ b/src/consumer.cc
@@ -34,19 +34,17 @@ Message Consumer_receive(Consumer& consumer) {
 
 Message Consumer_receive_timeout(Consumer& consumer, int timeoutMs) {
     Message msg;
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = consumer.receive(msg, timeoutMs);
-    Py_END_ALLOW_THREADS
 
-        CHECK_RESULT(res);
+    py::gil_scoped_release release;
+    CHECK_RESULT(consumer.receive(msg, timeoutMs));
     return msg;
 }
 
 Messages Consumer_batch_receive(Consumer& consumer) {
     Messages msgs;
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = consumer.batchReceive(msgs);
-    Py_END_ALLOW_THREADS CHECK_RESULT(res);
+
+    py::gil_scoped_release release;
+    CHECK_RESULT(consumer.batchReceive(msgs));
     return msgs;
 }
 
@@ -59,8 +57,8 @@ void Consumer_acknowledge_message_id(Consumer& consumer, const MessageId& msgId)
 }
 
 void Consumer_negative_acknowledge(Consumer& consumer, const Message& msg) {
-    Py_BEGIN_ALLOW_THREADS consumer.negativeAcknowledge(msg);
-    Py_END_ALLOW_THREADS
+    py::gil_scoped_release release;
+    consumer.negativeAcknowledge(msg);
 }
 
 void Consumer_negative_acknowledge_message_id(Consumer& consumer, const MessageId& msgId) {
@@ -97,11 +95,8 @@ bool Consumer_is_connected(Consumer& consumer) { return consumer.isConnected(); 
 
 MessageId Consumer_get_last_message_id(Consumer& consumer) {
     MessageId msgId;
-    Result res;
-    Py_BEGIN_ALLOW_THREADS res = consumer.getLastMessageId(msgId);
-    Py_END_ALLOW_THREADS
-
-        CHECK_RESULT(res);
+    py::gil_scoped_release release;
+    CHECK_RESULT(consumer.getLastMessageId(msgId));
     return msgId;
 }
 

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -30,10 +30,10 @@ MessageId Producer_send(Producer& producer, const Message& message) {
 }
 
 void Producer_sendAsync(Producer& producer, const Message& msg, SendCallback callback) {
-    Py_BEGIN_ALLOW_THREADS producer.sendAsync(msg, callback);
-    Py_END_ALLOW_THREADS
+    py::gil_scoped_release release;
+    producer.sendAsync(msg, callback);
 
-        if (PyErr_CheckSignals() == -1) {
+    if (PyErr_CheckSignals() == -1) {
         PyErr_SetInterrupt();
     }
 }


### PR DESCRIPTION
Use PyBind `py::gil_scoped_release` C++ class instead of the Python C Macros `Py_BEGIN_ALLOW_THREADS` for releasing / reacquiring the GIL.

This is just a code readability refactor.