### PR TITLE
Fix link failure on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,7 @@ endif()
 set(PYTHON_WRAPPER_LIBS
     ${PULSAR_LIBRARY}
 )
-if (MSVC)
-    set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS} Python3::Module)
-endif ()
+set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS} Python3::Module)
 
 message(STATUS "All libraries: ${PYTHON_WRAPPER_LIBS}")
 


### PR DESCRIPTION
### Motivation

We need to link the Python shared library on non-Windows systems as well. Otherwise, some link errors might happen.