### PR TITLE
feat: Support dead letter topic.

### DIFF
--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -379,29 +379,30 @@ class ConsumerDeadLetterPolicy:
     """
     Configuration for the "dead letter queue" feature in consumer.
     """
-    def __init__(self, dead_letter_topic: str = None,
-                 max_redeliver_count: int = None,
+    def __init__(self,
+                 max_redeliver_count: int,
+                 dead_letter_topic: str = None,
                  initial_subscription_name: str = None):
         """
         Wrapper DeadLetterPolicy.
 
         Parameters
         ----------
-        dead_letter_topic: Name of the dead topic where the failing messages are sent.
-            The default value is: sourceTopicName + "-" + subscriptionName + "-DLQ"
         max_redeliver_count: Maximum number of times that a message is redelivered before being sent to the dead letter queue.
             - The maxRedeliverCount must be greater than 0.
-            - The default value is None (DLQ is not enabled)
+        dead_letter_topic: Name of the dead topic where the failing messages are sent.
+            The default value is: sourceTopicName + "-" + subscriptionName + "-DLQ"
         initial_subscription_name: Name of the initial subscription name of the dead letter topic.
             If this field is not set, the initial subscription for the dead letter topic is not created.
             If this field is set but the broker's `allowAutoSubscriptionCreation` is disabled, the DLQ producer
             fails to be created.
         """
         builder = DeadLetterPolicyBuilder()
+        if max_redeliver_count is None or max_redeliver_count < 1:
+            raise ValueError("max_redeliver_count must be greater than 0")
+        builder.maxRedeliverCount(max_redeliver_count)
         if dead_letter_topic is not None:
             builder.deadLetterTopic(dead_letter_topic)
-        if max_redeliver_count is not None:
-            builder.maxRedeliverCount(max_redeliver_count)
         if initial_subscription_name is not None:
             builder.initialSubscriptionName(initial_subscription_name)
         self._policy = builder.build()

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -48,7 +48,7 @@ from typing import List, Tuple, Optional
 import _pulsar
 
 from _pulsar import Result, CompressionType, ConsumerType, InitialPosition, PartitionsRoutingMode, BatchingType, \
-    LoggerLevel, BatchReceivePolicy, KeySharedPolicy, KeySharedMode, ProducerAccessMode, RegexSubscriptionMode, \ 
+    LoggerLevel, BatchReceivePolicy, KeySharedPolicy, KeySharedMode, ProducerAccessMode, RegexSubscriptionMode, \
     DeadLetterPolicyBuilder  # noqa: F401
 
 from pulsar.__about__ import __version__

--- a/src/config.cc
+++ b/src/config.cc
@@ -22,6 +22,7 @@
 #include <pulsar/ConsumerConfiguration.h>
 #include <pulsar/ProducerConfiguration.h>
 #include <pulsar/KeySharedPolicy.h>
+#include <pulsar/DeadLetterPolicyBuilder.h>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -231,6 +232,20 @@ void export_config(py::module_& m) {
         .def("getMaxNumMessages", &BatchReceivePolicy::getMaxNumMessages)
         .def("getMaxNumBytes", &BatchReceivePolicy::getMaxNumBytes);
 
+    class_<DeadLetterPolicy>(m, "DeadLetterPolicy")
+        .def(init<>())
+        .def("getDeadLetterTopic", &DeadLetterPolicy::getDeadLetterTopic)
+        .def("getMaxRedeliverCount", &DeadLetterPolicy::getMaxRedeliverCount)
+        .def("getInitialSubscriptionName", &DeadLetterPolicy::getInitialSubscriptionName);
+
+    class_<DeadLetterPolicyBuilder>(m, "DeadLetterPolicyBuilder")
+        .def(init<>())
+        .def("deadLetterTopic", &DeadLetterPolicyBuilder::deadLetterTopic, return_value_policy::reference)
+        .def("maxRedeliverCount", &DeadLetterPolicyBuilder::maxRedeliverCount, return_value_policy::reference)
+        .def("initialSubscriptionName", &DeadLetterPolicyBuilder::initialSubscriptionName, return_value_policy::reference)
+        .def("build", &DeadLetterPolicyBuilder::build, return_value_policy::reference)
+        .def("build", &DeadLetterPolicyBuilder::build, return_value_policy::reference);
+
     class_<ConsumerConfiguration, std::shared_ptr<ConsumerConfiguration>>(m, "ConsumerConfiguration")
         .def(init<>())
         .def("key_shared_policy", &ConsumerConfiguration::getKeySharedPolicy)
@@ -285,7 +300,9 @@ void export_config(py::module_& m) {
              return_value_policy::reference)
         .def("batch_index_ack_enabled", &ConsumerConfiguration::isBatchIndexAckEnabled)
         .def("batch_index_ack_enabled", &ConsumerConfiguration::setBatchIndexAckEnabled,
-             return_value_policy::reference);
+             return_value_policy::reference)
+        .def("dead_letter_policy", &ConsumerConfiguration::setDeadLetterPolicy)
+        .def("dead_letter_policy", &ConsumerConfiguration::getDeadLetterPolicy, return_value_policy::copy);
 
     class_<ReaderConfiguration, std::shared_ptr<ReaderConfiguration>>(m, "ReaderConfiguration")
         .def(init<>())

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -44,6 +44,7 @@ from pulsar import (
     CryptoKeyReader,
     ConsumerBatchReceivePolicy,
     ProducerAccessMode,
+    ConsumerDeadLetterPolicy,
 )
 from pulsar.schema import JsonSchema, Record, Integer
 
@@ -1714,6 +1715,40 @@ class PulsarTest(TestCase):
         # assert no more msgs.
         with self.assertRaises(pulsar.Timeout):
             consumer.receive(timeout_millis=1000)
+        client.close()
+
+    def test_dead_letter_policy(self):
+        client = Client(self.serviceUrl)
+        topic = "my-python-topic-test-dlq" + str(time.time())
+        dlq_topic = 'dlq-' + topic
+        max_redeliver_count = 5
+        consumer = client.subscribe(topic, "my-sub", consumer_type=ConsumerType.Shared,
+                                    dead_letter_policy=ConsumerDeadLetterPolicy(dlq_topic, max_redeliver_count, 'init-sub'))
+        dlq_consumer = client.subscribe(dlq_topic, "my-sub", consumer_type=ConsumerType.Shared)
+
+        # Sen num msgs.
+        producer = client.create_producer(topic)
+        num = 10
+        for i in range(num):
+            producer.send(b"hello-%d" % i)
+        producer.flush()
+
+        # Redelivery all messages maxRedeliverCountNum time.
+        for i in range(1, num * max_redeliver_count + num + 1):
+            msg = consumer.receive()
+            if i % num == 0:
+                consumer.redeliver_unacknowledged_messages()
+                print(f"Start redeliver msgs '{i}'")
+        with self.assertRaises(pulsar.Timeout):
+            consumer.receive(100)
+
+        for i in range(num):
+            msg = dlq_consumer.receive()
+            self.assertTrue(msg)
+            self.assertEqual(msg.data(), b"hello-%d" % i)
+            dlq_consumer.acknowledge(msg)
+        with self.assertRaises(pulsar.Timeout):
+            dlq_consumer.receive(100)
 
         client.close()
 

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -1717,13 +1717,22 @@ class PulsarTest(TestCase):
             consumer.receive(timeout_millis=1000)
         client.close()
 
+    def test_dead_letter_policy_config(self):
+        with self.assertRaises(ValueError):
+            ConsumerDeadLetterPolicy(-1)
+
+        policy = ConsumerDeadLetterPolicy(10)
+        self.assertEqual(10, policy.max_redeliver_count)
+        self.assertEqual("", policy.dead_letter_topic)
+        self.assertEqual("", policy.initial_subscription_name)
+
     def test_dead_letter_policy(self):
         client = Client(self.serviceUrl)
         topic = "my-python-topic-test-dlq" + str(time.time())
         dlq_topic = 'dlq-' + topic
         max_redeliver_count = 5
         consumer = client.subscribe(topic, "my-sub", consumer_type=ConsumerType.Shared,
-                                    dead_letter_policy=ConsumerDeadLetterPolicy(dlq_topic, max_redeliver_count, 'init-sub'))
+                                    dead_letter_policy=ConsumerDeadLetterPolicy(max_redeliver_count, dlq_topic, 'init-sub'))
         dlq_consumer = client.subscribe(dlq_topic, "my-sub", consumer_type=ConsumerType.Shared)
 
         # Sen num msgs.


### PR DESCRIPTION
### Motivation

#98 Support dead letter topic.

### Modifications
- Add  `ConsumerDeadLetterPolicy `.
- Add dlq_policy param on the `client.subscribe` method.


### Verifying this change
- Add `test_dead_letter_policy` to cover trigger send dlq topic by `redeliver_unacknowledged_messages `, other case covered by cpp client.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
