### PR TITLE
feat: support producer access mode.

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -223,7 +223,9 @@ void export_config(py::module_& m) {
         .def("batching_type", &ProducerConfiguration::setBatchingType, return_value_policy::reference)
         .def("batching_type", &ProducerConfiguration::getBatchingType)
         .def("encryption_key", &ProducerConfiguration::addEncryptionKey, return_value_policy::reference)
-        .def("crypto_key_reader", &ProducerConfiguration::setCryptoKeyReader, return_value_policy::reference);
+        .def("crypto_key_reader", &ProducerConfiguration::setCryptoKeyReader, return_value_policy::reference)
+        .def("access_mode", &ProducerConfiguration::setAccessMode, return_value_policy::reference)
+        .def("access_mode", &ProducerConfiguration::getAccessMode, return_value_policy::copy);
 
     class_<BatchReceivePolicy>(m, "BatchReceivePolicy")
         .def(init<int, int, long>())

--- a/src/enums.cc
+++ b/src/enums.cc
@@ -124,6 +124,12 @@ void export_enums(py::module_& m) {
         .value("Default", ProducerConfiguration::DefaultBatching)
         .value("KeyBased", ProducerConfiguration::KeyBasedBatching);
 
+    enum_<ProducerConfiguration::ProducerAccessMode>(m, "ProducerAccessMode", "Producer Access Mode")
+        .value("Shared", ProducerConfiguration::ProducerAccessMode::Shared)
+        .value("Exclusive", ProducerConfiguration::ProducerAccessMode::Exclusive)
+        .value("WaitForExclusive", ProducerConfiguration::ProducerAccessMode::WaitForExclusive)
+        .value("ExclusiveWithFencing", ProducerConfiguration::ProducerAccessMode::ExclusiveWithFencing);
+
     enum_<Logger::Level>(m, "LoggerLevel")
         .value("Debug", Logger::LEVEL_DEBUG)
         .value("Info", Logger::LEVEL_INFO)

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -216,9 +216,10 @@ class PulsarTest(TestCase):
         assert producer2.producer_name() == 'p-2'
 
         # producer1 will be fenced.
-        time.sleep(0.2)
         with self.assertRaises((pulsar.ProducerFenced, pulsar.AlreadyClosed)):
             producer1.send('test-msg'.encode('utf-8'))
+        # sleep 200ms to make sure producer1 is close done.
+        time.sleep(0.2)
 
         producer2.close()
         client.close()


### PR DESCRIPTION
### Motivation

#74 

### Modifications

- Expose the producer access mode option.

### Verifying this change

- Add unit test to cover it.

### Documentation

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

Need to add examples docs on here: https://pulsar.apache.org/docs/3.0.x/client-libraries-producers/#configure-access-mode
