### PR TITLE
Fix the OpenSSL 3.x symbols not found on macOS build

### DIFF
--- a/pkg/mac/build-dependencies.sh
+++ b/pkg/mac/build-dependencies.sh
@@ -194,7 +194,9 @@ if [ ! -f curl-${CURL_VERSION}/.done ]; then
     CURL_VERSION_=${CURL_VERSION//./_}
     download_dependency $ROOT_DIR/dependencies.yaml curl
     pushd curl-${CURL_VERSION}
-      CFLAGS="-fPIC -arch arm64 -arch x86_64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
+      # Force the compiler to find the OpenSSL headers instead of the headers in the system path like /usr/local/include/openssl.
+      cp -rf $PREFIX/include/openssl include/
+      CFLAGS="-I$PREFIX/include -fPIC -arch arm64 -arch x86_64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
             ./configure --with-ssl=$PREFIX \
               --without-nghttp2 \
               --without-libidn2 \

--- a/pkg/mac/build-pulsar-cpp.sh
+++ b/pkg/mac/build-pulsar-cpp.sh
@@ -45,12 +45,14 @@ if [ ! -f apache-pulsar-client-cpp-${PULSAR_CPP_VERSION}/.done ]; then
       ARCHS='arm64;x86_64'
 
       cmake . \
+              -DCMAKE_CXX_STANDARD=11 \
               -DCMAKE_OSX_ARCHITECTURES=${ARCHS} \
               -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_PREFIX_PATH=${DEPS_PREFIX} \
               -DCMAKE_CXX_FLAGS=-I${DEPS_PREFIX}/include \
+              -DOPENSSL_ROOT_DIR=${DEPS_PREFIX} \
               -DLINK_STATIC=OFF \
               -DBUILD_TESTS=OFF \
               -DBUILD_WIRESHARK=OFF \


### PR DESCRIPTION
### Motivation

Recently after the runner image was upgraded, the macOS build failed with `symbol not found in flat namespace (_EVP_PKEY_get_bn_param)`.

See https://github.com/apache/pulsar-client-python/actions/runs/5805986979/job/15740588663?pr=134

There are actually two issues.

One is that when building the C++ client on macOS, `/usr/local/opt/openssl/` will be firstly searched if `OPENSSL_ROOT_DIR` is not defined.

https://github.com/apache/pulsar-client-cpp/blob/1e7d259bb94379ef6e4618fdac283912d0be6861/CMakeLists.txt#L136

It should be fixed at the C++ client side but we can also have a workaround here by defining the `OPENSSL_ROOT_DIR` variable.

The other is that when building the libcurl, the headers from `/usr/local/include/openssl/` were included, see the logs:

```
/usr/local/include/openssl/macros.h:193:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
```

It's a strange error because we have already configured the `--with-ssl` option to specify the OpenSSL directory. I tried adding `-I/path/to/my/openssl` to the `CFLAGS` env variable but it didn't work.

### Modifications

To resolve the 1st issue, specifying `OPENSSL_ROOT_DIR` to the `DEPS_PREFIX` path when building the C++ client.

To resolve the 2nd issue, since I cannot find an elegant way to do that, I just copied the OpenSSL headers from the dependency header directory to the libcurl include directory.