### PR TITLE
Upgrade the C++ client to 3.3.0 

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -18,7 +18,7 @@
 #
 
 cmake: 3.24.2
-pulsar-cpp: 3.2.0
+pulsar-cpp: 3.3.0
 pybind11: 2.10.1
 boost: 1.80.0
 protobuf: 3.20.0

--- a/pkg/mac/build-dependencies.sh
+++ b/pkg/mac/build-dependencies.sh
@@ -150,10 +150,12 @@ if [ ! -f protobuf-${PROTOBUF_VERSION}/.done ]; then
     echo "Building Protobuf"
     download_dependency $ROOT_DIR/dependencies.yaml protobuf
     pushd protobuf-${PROTOBUF_VERSION}
-      CXXFLAGS="-fPIC -arch arm64 -arch x86_64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
-            ./configure --prefix=$PREFIX
-      make -j16
-      make install
+      # Install by CMake so that the dependency can be found with CMake config mode
+      pushd cmake/
+        cmake -B build -DCMAKE_CXX_FLAGS="-fPIC -arch arm64 -arch x86_64 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
+            -DCMAKE_INSTALL_PREFIX=$PREFIX
+        cmake --build build -j16 --target install
+      popd
       touch .done
     popd
 else

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -426,7 +426,8 @@ class Client:
             Number of concurrent lookup-requests allowed on each broker connection to prevent overload
             on the broker.
         log_conf_file_path: str, optional
-            Initialize log4cxx from a configuration file.
+            This parameter is deprecated and makes no effect. It's retained only for compatibility.
+            Use `logger` to customize a logger.
         use_tls: bool, default=False
             Configure whether to use TLS encryption on the connection. This setting is deprecated.
             TLS will be automatically enabled if the ``serviceUrl`` is set to ``pulsar+ssl://`` or ``https://``
@@ -468,8 +469,6 @@ class Client:
         conf.io_threads(io_threads)
         conf.message_listener_threads(message_listener_threads)
         conf.concurrent_lookup_requests(concurrent_lookup_requests)
-        if log_conf_file_path:
-            conf.log_conf_file_path(log_conf_file_path)
 
         if isinstance(logger, logging.Logger):
             conf.set_logger(self._prepare_logger(logger))

--- a/src/config.cc
+++ b/src/config.cc
@@ -156,8 +156,6 @@ void export_config(py::module_& m) {
         .def("concurrent_lookup_requests", &ClientConfiguration::getConcurrentLookupRequest)
         .def("concurrent_lookup_requests", &ClientConfiguration::setConcurrentLookupRequest,
              return_value_policy::reference)
-        .def("log_conf_file_path", &ClientConfiguration::getLogConfFilePath, return_value_policy::copy)
-        .def("log_conf_file_path", &ClientConfiguration::setLogConfFilePath, return_value_policy::reference)
         .def("use_tls", &ClientConfiguration::isUseTls)
         .def("use_tls", &ClientConfiguration::setUseTls, return_value_policy::reference)
         .def("tls_trust_certs_file_path", &ClientConfiguration::getTlsTrustCertsFilePath,

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -773,7 +773,6 @@ class PulsarTest(TestCase):
         self._check_value_error(lambda: Client(self.serviceUrl, io_threads="test"))
         self._check_value_error(lambda: Client(self.serviceUrl, message_listener_threads="test"))
         self._check_value_error(lambda: Client(self.serviceUrl, concurrent_lookup_requests="test"))
-        self._check_value_error(lambda: Client(self.serviceUrl, log_conf_file_path=5))
         self._check_value_error(lambda: Client(self.serviceUrl, use_tls="test"))
         self._check_value_error(lambda: Client(self.serviceUrl, tls_trust_certs_file_path=5))
         self._check_value_error(lambda: Client(self.serviceUrl, tls_allow_insecure_connection="test"))


### PR DESCRIPTION
### Modifications

Upgrade the C++ client to 3.3.0 and deprecate the `log_conf_file_path`
config due to https://github.com/apache/pulsar-client-cpp/pull/283.

There is another issue that after
https://github.com/apache/pulsar-client-cpp/pull/290, the CMakeLists.txt
from the C++ client finds the protobuf package with config mode. To fix
it, install the OpenSSL via CMake instead of the autotools.