### PR TITLE
[feat] Support schema field type promotion

### DIFF
--- a/pulsar/schema/definition.py
+++ b/pulsar/schema/definition.py
@@ -228,7 +228,7 @@ class Field(object):
         if val is None and not self._required:
             return self.default()
 
-        if type(val) != self.python_type():
+        if not isinstance(val, self.python_type()):
             raise TypeError("Invalid type '%s' for field '%s'. Expected: %s" % (type(val), name, _string_representation(self.python_type())))
         return val
 
@@ -309,7 +309,7 @@ class Float(Field):
         return 'float'
 
     def python_type(self):
-        return float
+        return float, int
 
     def default(self):
         if self._default is not None:
@@ -323,7 +323,7 @@ class Double(Field):
         return 'double'
 
     def python_type(self):
-        return float
+        return float, int
 
     def default(self):
         if self._default is not None:
@@ -337,7 +337,7 @@ class Bytes(Field):
         return 'bytes'
 
     def python_type(self):
-        return bytes
+        return bytes, str
 
     def default(self):
         if self._default is not None:
@@ -345,13 +345,18 @@ class Bytes(Field):
         else:
             return None
 
+    def validate_type(self, name, val):
+        if isinstance(val, str):
+            return val.encode()
+        return val
+
 
 class String(Field):
     def type(self):
         return 'string'
 
     def python_type(self):
-        return str
+        return str, bytes
 
     def validate_type(self, name, val):
         t = type(val)
@@ -359,8 +364,10 @@ class String(Field):
         if val is None and not self._required:
             return self.default()
 
-        if not (t is str or t.__name__ == 'unicode'):
+        if not (isinstance(val, (str, bytes)) or t.__name__ == 'unicode'):
             raise TypeError("Invalid type '%s' for field '%s'. Expected a string" % (t, name))
+        if isinstance(val, bytes):
+            return val.decode()
         return val
 
     def default(self):
@@ -406,7 +413,7 @@ class CustomEnum(Field):
             else:
                 raise TypeError(
                     "Invalid enum value '%s' for field '%s'. Expected: %s" % (val, name, self.values.keys()))
-        elif type(val) != self.python_type():
+        elif not isinstance(val, self.python_type()):
             raise TypeError("Invalid type '%s' for field '%s'. Expected: %s" % (type(val), name, _string_representation(self.python_type())))
         else:
             return val
@@ -493,7 +500,7 @@ class Map(Field):
         for k, v in val.items():
             if type(k) != str and not is_unicode(k):
                 raise TypeError('Map keys for field ' + name + '  should all be strings')
-            if type(v) != self.value_type.python_type():
+            if not isinstance(val, self.value_type.python_type()):
                 raise TypeError('Map values for field ' + name + ' should all be of type '
                                 + _string_representation(self.value_type.python_type()))
 

--- a/pulsar/schema/definition.py
+++ b/pulsar/schema/definition.py
@@ -457,7 +457,7 @@ class Array(Field):
         super(Array, self).validate_type(name, val)
 
         for x in val:
-            if type(x) != self.array_type.python_type():
+            if not isinstance(x, self.array_type.python_type()):
                 raise TypeError('Array field ' + name + ' items should all be of type ' +
                                 _string_representation(self.array_type.type()))
         return val
@@ -500,7 +500,7 @@ class Map(Field):
         for k, v in val.items():
             if type(k) != str and not is_unicode(k):
                 raise TypeError('Map keys for field ' + name + '  should all be strings')
-            if not isinstance(val, self.value_type.python_type()):
+            if not isinstance(v, self.value_type.python_type()):
                 raise TypeError('Map values for field ' + name + ' should all be of type '
                                 + _string_representation(self.value_type.python_type()))
 

--- a/pulsar/schema/schema.py
+++ b/pulsar/schema/schema.py
@@ -101,6 +101,8 @@ class JsonSchema(Schema):
     def _get_serialized_value(self, o):
         if isinstance(o, enum.Enum):
             return o.value
+        elif isinstance(o, bytes):
+            return o.decode()
         else:
             data = o.__dict__.copy()
             remove_reserved_key(data)

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -260,7 +260,7 @@ class SchemaTest(TestCase):
             a = Float()
 
         E3(a=1.0)  # Ok
-        self._expectTypeError(lambda:  E3(a=1))
+        E3(a=1) # Ok Type promotion: int -> float
 
         class E4(Record):
             a = Null()
@@ -290,7 +290,7 @@ class SchemaTest(TestCase):
             a = Double()
 
         E7(a=1.0)  # Ok
-        self._expectTypeError(lambda:  E3(a=1))
+        E7(a=1)  # Ok Type promotion: int -> double
 
         class Color(Enum):
             red = 1


### PR DESCRIPTION
## Motivation

The client is not correctly following [Avro's type promotion rules](https://avro.apache.org/docs/1.11.1/specification/#schema-resolution), leading to a potential problem with data serialization and deserialization.

The expected behavior is that the Python client should correctly follow Avro's type promotion rules and perform type conversion when necessary, ensuring compatibility. However the actual behavior is that the Python client's schema deserialization is too strict, and type promotion is not happening as expected.

## Modification

- Support schema field type promotion when validating the python type
- Convert the field value to the desired compatible python type



