### PR TITLE
Fix incorrect python spec name for release wheels workflow

### DIFF
--- a/.github/workflows/ci-build-release-wheels.yaml
+++ b/.github/workflows/ci-build-release-wheels.yaml
@@ -46,7 +46,7 @@ jobs:
           - {version: '3.9', spec: 'cp39-cp39'}
           - {version: '3.10', spec: 'cp310-cp310'}
           - {version: '3.11', spec: 'cp311-cp311'}
-          - {version: '3.12', spec: 'cp311-cp312'}
+          - {version: '3.12', spec: 'cp312-cp312'}
         cpu:
           - {arch: 'x86_64', platform: 'x86_64'}
           - {arch: 'aarch64', platform: 'arm64'}


### PR DESCRIPTION
There is an error when building the wheel for python12:
```
Dockerfile:35
--------------------
  33 |     ENV PYTHON_LIBRARIES   /opt/python/${PYTHON_SPEC}/lib/python${PYTHON_VERSION}
  34 |     
  35 | >>> RUN pip3 install pyyaml
  36 |     
  37 |     ADD .build/dependencies.yaml /
--------------------
```
More context: https://github.com/apache/pulsar-client-python/actions/runs/7246274042/job/19737879474#step:6:237

The python spec name is incorrect in the github release wheels workflow. These are all specs in the manylinux2014:
```
[root@82c96c919b6f /]# cd /opt/python/
[root@82c96c919b6f python]# ll
total 0
lrwxrwxrwx 1 root root 30 Dec 18 19:58 cp310-cp310 -> /opt/_internal/cpython-3.10.13
lrwxrwxrwx 1 root root 29 Dec 18 19:57 cp311-cp311 -> /opt/_internal/cpython-3.11.7
lrwxrwxrwx 1 root root 29 Dec 18 19:57 cp312-cp312 -> /opt/_internal/cpython-3.12.1
lrwxrwxrwx 1 root root 29 Dec 18 19:57 cp36-cp36m -> /opt/_internal/cpython-3.6.15
lrwxrwxrwx 1 root root 29 Dec 18 19:57 cp37-cp37m -> /opt/_internal/cpython-3.7.17
lrwxrwxrwx 1 root root 29 Dec 18 19:57 cp38-cp38 -> /opt/_internal/cpython-3.8.18
lrwxrwxrwx 1 root root 29 Dec 18 19:57 cp39-cp39 -> /opt/_internal/cpython-3.9.18
lrwxrwxrwx 1 root root 33 Dec 18 19:58 pp310-pypy310_pp73 -> /opt/_internal/pp310-pypy310_pp73
lrwxrwxrwx 1 root root 31 Dec 18 19:58 pp37-pypy37_pp73 -> /opt/_internal/pp37-pypy37_pp73
lrwxrwxrwx 1 root root 31 Dec 18 19:58 pp38-pypy38_pp73 -> /opt/_internal/pp38-pypy38_pp73
lrwxrwxrwx 1 root root 31 Dec 18 19:58 pp39-pypy39_pp73 -> /opt/_internal/pp39-pypy39_pp73
```

This PR fixes the incorrect spec name for python12.