### PR TITLE
Fix incorrect version upgrade command in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,7 +58,7 @@ For major and minor releases (`X.Y.0`), you need to create a new branch:
 
 ```bash
 git checkout -b branch-X.Y
-sed -i 's/__version__.*/__version__=X.Y.0/' pulsar/__about__.py
+perl -pi -e "s/__version__.*/__version__='X.Y.Z'/" pulsar/__about__.py
 git add pulsar/__about__.py
 git commit -m "Bump version to X.Y.0"
 git push origin branch-X.Y
@@ -71,7 +71,7 @@ For patch releases (`X.Y.Z`), you need to reuse the existing branch:
 
 ```bash
 git checkout branch-X.Y
-perl -pi -e "s/__version__.*/__version__=\"X.Y.Z\"/" pulsar/__about__.py
+perl -pi -e "s/__version__.*/__version__='X.Y.Z'/" pulsar/__about__.py
 git add pulsar/__about__.py
 git commit -m "Bump version to X.Y.Z"
 git push origin branch-X.Y
@@ -164,7 +164,7 @@ You need to move the main version to the next iteration.
 
 ```bash
 git checkout main
-sed -i.bak 's/X.Y.0a1/X.Y+1.0a1/' pulsar/__about__.py
+perl -pi -e "s/X.Y.0a1/X.Y+1.0a1/" pulsar/__about__.py
 git add pulsar/__about__.py
 git commit -m "Bumped version to X.Y.0a1"
 ```


### PR DESCRIPTION
The current upgrade version command in RELEASE.md will fail the release CI:

```
ERROR: pulsar_client-"3.4.0"-cp37-*-macosx_10_15_universal2.whl is not a supported wheel on this platform.
```
https://github.com/apache/pulsar-client-python/actions/runs/7269467100/job/19807133709#step:7:196

This PR fix this issue.