### PR TITLE
Fix negative acknowledge on a message ID does not work

### DIFF
--- a/src/consumer.cc
+++ b/src/consumer.cc
@@ -64,7 +64,8 @@ void Consumer_negative_acknowledge(Consumer& consumer, const Message& msg) {
 }
 
 void Consumer_negative_acknowledge_message_id(Consumer& consumer, const MessageId& msgId) {
-    waitForAsyncResult([&](ResultCallback callback) { consumer.acknowledgeAsync(msgId, callback); });
+    Py_BEGIN_ALLOW_THREADS consumer.negativeAcknowledge(msgId);
+    Py_END_ALLOW_THREADS
 }
 
 void Consumer_acknowledge_cumulative(Consumer& consumer, const Message& msg) {

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -286,7 +286,10 @@ class PulsarTest(TestCase):
         for i in range(4):
             msg = consumer.receive(TM)
             print("Received message %s" % msg.data())
-            consumer.negative_acknowledge(msg)
+            if i % 2 == 0:
+                consumer.negative_acknowledge(msg)
+            else:
+                consumer.negative_acknowledge(msg.message_id())
             redelivery_count = msg.redelivery_count()
 
         self.assertTrue(msg)


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-python/issues/178

### Motivation

https://github.com/apache/pulsar-client-python/pull/121 introduces a regression that when `negative_acknowledge` accepts a message ID, the underlying `acknowledgeAsync` method will be called.

### Modifications

Fix the `Consumer_negative_acknowledge_message_id` method and add the test for negative acknowledging message IDs in `test_redelivery_count`.