### PR TITLE
Fix the incompatibility with Python 3.12 and drop the support for 3.7

### DIFF
--- a/.github/workflows/ci-build-release-wheels.yaml
+++ b/.github/workflows/ci-build-release-wheels.yaml
@@ -41,7 +41,6 @@ jobs:
           - {name: 'manylinux2014', py_suffix: ''}
           - {name: 'manylinux_musl', py_suffix: '-alpine'}
         python:
-          - {version: '3.7', spec: 'cp37-cp37m'}
           - {version: '3.8', spec: 'cp38-cp38'}
           - {version: '3.9', spec: 'cp39-cp39'}
           - {version: '3.10', spec: 'cp310-cp310'}
@@ -103,7 +102,6 @@ jobs:
       fail-fast: false
       matrix:
         py:
-          - {version: '3.7', version_long:  '3.7.15'}
           - {version: '3.8', version_long:  '3.8.13'}
           - {version: '3.9', version_long:  '3.9.14'}
           - {version: '3.10', version_long:  '3.10.7'}
@@ -156,7 +154,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - {version: '3.7'}
           - {version: '3.8'}
           - {version: '3.9'}
           - {version: '3.10'}

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -47,13 +47,22 @@ jobs:
             pulsar
 
   unit-tests:
-    name: Run unit tests
+    name: Run unit tests for Python ${{matrix.version}}
     runs-on: ubuntu-22.04
     timeout-minutes: 120
 
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['3.8', '3.12']
+
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "${{matrix.version}}"
 
       - name: Install Pulsar C++ client
         run: build-support/install-dependencies.sh
@@ -66,7 +75,8 @@ jobs:
 
       - name: Python install
         run: |
-            ./setup.py bdist_wheel
+            python3 -m pip install -U pip setuptools wheel requests
+            python3 setup.py bdist_wheel
             WHEEL=$(find dist -name '*.whl')
             pip3 install ${WHEEL}[avro]
 
@@ -90,7 +100,7 @@ jobs:
       - name: Test functions install
         run: |
             WHEEL=$(find dist -name '*.whl')
-            pip3 install ${WHEEL}[functions] --force-reinstall
+            pip3 install ${WHEEL}[all] --force-reinstall
 
   linux-wheel:
     name: Wheel ${{matrix.image.name}} - Py ${{matrix.python.version}} - ${{matrix.cpu.platform}}

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -163,7 +163,7 @@ jobs:
     strategy:
       matrix:
         py:
-          - {version: '3.11', version_long:  '3.11.1'}
+          - {version: '3.12', version_long:  '3.12.0'}
 
     steps:
       - name: checkout
@@ -209,7 +209,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - version: '3.11'
+          - version: '3.12'
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pulsar Python clients support a variety of Pulsar features to enable building ap
 
 ## Requirements
 
-- Python >= 3.7
+- Python 3.8, 3.9, 3.10, 3.11, 3.12
 - A C++ compiler that supports C++11
 - CMake >= 3.18
 - [Pulsar C++ client library](https://github.com/apache/pulsar-client-cpp)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -132,7 +132,7 @@ stay open for at least 72 hours ***
 Python wheels:
 https://dist.apache.org/repos/dist/dev/pulsar/pulsar-client-python-X.Y.Z-candidate-N/
 
-The supported python versions are 3.7, 3.8, 3.9, 3.10, 3.11 and 3.12. The
+The supported python versions are 3.8, 3.9, 3.10, 3.11 and 3.12. The
 supported platforms and architectures are:
 - Windows x86_64 (windows/)
 - glibc-based Linux x86_64 (linux-glibc-x86_64/)

--- a/build-support/install-dependencies.sh
+++ b/build-support/install-dependencies.sh
@@ -22,6 +22,7 @@ set -e -x
 
 cd `dirname $0`
 
+python3 -m pip install pyyaml
 CPP_CLIENT_VERSION=$(./dep-version.py pulsar-cpp ../dependencies.yaml)
 PYBIND11_VERSION=$(./dep-version.py pybind11 ../dependencies.yaml)
 source ./dep-url.sh

--- a/pkg/mac/build-dependencies.sh
+++ b/pkg/mac/build-dependencies.sh
@@ -72,33 +72,6 @@ else
 fi
 
 ###############################################################################
-if [ ! -f Python-${PYTHON_VERSION_LONG}/.done ]; then
-  echo "Building Python $PYTHON_VERSION_LONG"
-  curl -O -L https://www.python.org/ftp/python/${PYTHON_VERSION_LONG}/Python-${PYTHON_VERSION_LONG}.tgz
-  tar xfz Python-${PYTHON_VERSION_LONG}.tgz
-
-  pushd Python-${PYTHON_VERSION_LONG}
-      if [ $PYTHON_VERSION = '3.7' ]; then
-          patch -p1 < ${ROOT_DIR}/pkg/mac/python-3.7.patch
-      fi
-
-      CFLAGS="-fPIC -O3 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} -I${PREFIX}/include ${PY_CFLAGS}" \
-          LDFLAGS=" ${PY_CFLAGS} -L${PREFIX}/lib" \
-          ./configure --prefix=$PREFIX --enable-shared --enable-universalsdk --with-universal-archs=universal2
-      make -j16
-      make install
-
-      curl -O -L https://files.pythonhosted.org/packages/27/d6/003e593296a85fd6ed616ed962795b2f87709c3eee2bca4f6d0fe55c6d00/wheel-0.37.1-py2.py3-none-any.whl
-      $PREFIX/bin/pip3 install wheel setuptools
-      $PREFIX/bin/pip3 install wheel-*.whl
-
-      touch .done
-  popd
-else
-  echo "Using cached Python $PYTHON_VERSION_LONG"
-fi
-
-###############################################################################
 OPENSSL_VERSION_UNDERSCORE=$(echo $OPENSSL_VERSION | sed 's/\./_/g')
 if [ ! -f openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done ]; then
     echo "Building OpenSSL"
@@ -134,6 +107,35 @@ if [ ! -f openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done ]; then
     touch openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.done
 else
     echo "Using cached OpenSSL"
+fi
+
+###############################################################################
+if [ ! -f Python-${PYTHON_VERSION_LONG}/.done ]; then
+  echo "Building Python $PYTHON_VERSION_LONG"
+  curl -O -L https://www.python.org/ftp/python/${PYTHON_VERSION_LONG}/Python-${PYTHON_VERSION_LONG}.tgz
+  tar xfz Python-${PYTHON_VERSION_LONG}.tgz
+
+  pushd Python-${PYTHON_VERSION_LONG}
+      if [ $PYTHON_VERSION = '3.7' ]; then
+          patch -p1 < ${ROOT_DIR}/pkg/mac/python-3.7.patch
+      fi
+
+      CFLAGS="-fPIC -O3 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} -I${PREFIX}/include ${PY_CFLAGS}" \
+          LDFLAGS=" ${PY_CFLAGS} -L${PREFIX}/lib" \
+          ./configure --prefix=$PREFIX --enable-shared --enable-universalsdk \
+              --with-universal-archs=universal2 \
+              --with-openssl=$PREFIX
+      make -j16
+      make install
+
+      curl -O -L https://files.pythonhosted.org/packages/27/d6/003e593296a85fd6ed616ed962795b2f87709c3eee2bca4f6d0fe55c6d00/wheel-0.37.1-py2.py3-none-any.whl
+      $PREFIX/bin/pip3 install wheel setuptools
+      $PREFIX/bin/pip3 install wheel-*.whl
+
+      touch .done
+  popd
+else
+  echo "Using cached Python $PYTHON_VERSION_LONG"
 fi
 
 ###############################################################################

--- a/pkg/mac/build-dependencies.sh
+++ b/pkg/mac/build-dependencies.sh
@@ -89,6 +89,7 @@ if [ ! -f Python-${PYTHON_VERSION_LONG}/.done ]; then
       make install
 
       curl -O -L https://files.pythonhosted.org/packages/27/d6/003e593296a85fd6ed616ed962795b2f87709c3eee2bca4f6d0fe55c6d00/wheel-0.37.1-py2.py3-none-any.whl
+      $PREFIX/bin/pip3 install wheel setuptools
       $PREFIX/bin/pip3 install wheel-*.whl
 
       touch .done

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ extras_require["functions"] = sorted(
 # avro dependencies
 extras_require["avro"] = sorted(
     {
-      "fastavro==1.7.3"
+      "fastavro>=1.9.2"
     }
 )
 

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -449,7 +449,7 @@ class SchemaTest(TestCase):
 
         self.assertIsNotNone(msg.schema_version())
 
-        self.assertEquals(b'\x00\x00\x00\x00\x00\x00\x00\x00', msg.schema_version().encode())
+        self.assertEqual(b'\x00\x00\x00\x00\x00\x00\x00\x00', msg.schema_version().encode())
 
         self.assertEqual(r, msg.value())
 


### PR DESCRIPTION
### Motivation

The `avro` component cannot be installed with Python 3.12 because the depended `fastavro` dependency is 1.7.3, which is not compatible with Python 3.12. However, the newer fastavro dependencies all do not support Python 3.7, which has already reached the EOL (2023-06-27).

### Modifications

- Upgrade the fastavro dependency to 1.9.2
- Add the workflows to run tests for the lowest and highest supported Python versions (3.8 and 3.12).
- Fix the documents