### PR TITLE
Fix windows release CI doesn't show the python version

### DIFF
--- a/.github/workflows/ci-build-release-wheels.yaml
+++ b/.github/workflows/ci-build-release-wheels.yaml
@@ -146,7 +146,7 @@ jobs:
           path: dist/*.whl
 
   windows-wheels:
-    name: Wheel Windows - Py ${{matrix.py.version}}
+    name: Wheel Windows - Py ${{matrix.python.version}}
     runs-on: windows-2019
     env:
       PULSAR_CPP_DIR: 'C:\\pulsar-cpp'


### PR DESCRIPTION
The windows CI title missing the python version: https://github.com/apache/pulsar-client-python/actions/runs/7320564743/job/19942264135 The Ci title points to the incorrect matrix.

This PR fixes this issue.