### PR TITLE
Fix missing dependency of setuptools

### DIFF
--- a/.github/workflows/ci-build-release-wheels.yaml
+++ b/.github/workflows/ci-build-release-wheels.yaml
@@ -199,7 +199,7 @@ jobs:
         shell: bash
         run: |
           cmake --build build --config Release --target install
-          python -m pip install wheel
+          python -m pip install wheel setuptools
           python setup.py bdist_wheel
           python -m pip install ./dist/*.whl
           python -c 'import pulsar; c = pulsar.Client("pulsar://localhost:6650"); c.close()'

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -237,7 +237,7 @@ jobs:
         shell: bash
         run: |
           cmake --build build --config Release --target install
-          python -m pip install wheel
+          python -m pip install wheel setuptools
           python setup.py bdist_wheel
           python -m pip install ./dist/*.whl
           python -c 'import pulsar; c = pulsar.Client("pulsar://localhost:6650"); c.close()'

--- a/pkg/mac/build-dependencies.sh
+++ b/pkg/mac/build-dependencies.sh
@@ -29,7 +29,7 @@ PYTHON_VERSION_LONG=$2
 source pkg/mac/common.sh
 source build-support/dep-url.sh
 
-pip3 install pyyaml
+pip3 install pyyaml setuptools
 
 dep=$ROOT_DIR/build-support/dep-version.py
 PYBIND11_VERSION=$($dep pybind11)


### PR DESCRIPTION
## Motivation

There are some errors blocking the CI:
https://github.com/apache/pulsar-client-python/actions/runs/7321925272/job/19942911045?pr=181
https://github.com/apache/pulsar-client-python/actions/runs/7320564743/job/19942264377

The python 3.12 has removed the setuptools for the default dependency by this PR: https://github.com/python/cpython/issues/95299

> [gh-95299](https://github.com/python/cpython/issues/95299): Do not pre-install setuptools in virtual environments created with [venv](https://docs.python.org/3/library/venv.html#module-venv). This means that distutils, setuptools, pkg_resources, and easy_install will no longer available by default; to access these run pip install setuptools in the [activated](https://docs.python.org/3/library/venv.html#venv-explanation) virtual environment.

## Verification

Verification CI: https://github.com/apache/pulsar-client-python/actions/runs/7325997832

The result of CI shows that this fix could build the release wheel file successfully.

