### PR TITLE
Document the requirement for the send_async method

### DIFF
--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -1237,6 +1237,8 @@ class Producer:
         --------
 
         The ``callback`` will be invoked once the message has been acknowledged by the broker.
+        Users are responsible to handle the exception inside the callback. If any exception was
+        thrown from the callback, the process would terminate immediately.
 
         .. code-block:: python
 


### PR DESCRIPTION
See https://github.com/apache/pulsar-client-python/issues/184

It should be documented that the callback should not throw any exception when passed to `send_async`.