### PR TITLE
Fix incorrect logs when a message failed to be decoded with the writer schema

### DIFF
--- a/pulsar/schema/schema_avro.py
+++ b/pulsar/schema/schema_avro.py
@@ -91,7 +91,8 @@ if HAS_AVRO:
                 writer_schema = self._get_writer_schema(topic, version)
                 return self._decode_bytes(msg.data(), writer_schema)
             except Exception as e:
-                self._logger.error(f'Failed to get schema info of {topic} version {version}: {e}')
+                msg_id = msg.message_id()
+                self._logger.warn(f'Failed to decode {msg_id} with schema {topic} version {version}: {e}')
                 return self._decode_bytes(msg.data(), self._schema)
 
         def _get_writer_schema(self, topic: str, version: int) -> 'dict':


### PR DESCRIPTION
### Motivation

See
https://github.com/apache/pulsar-client-python/blob/f9b2d168ae85f289d6ee043cd81791d569ba8844/pulsar/schema/schema_avro.py#L92C32-L92C69

When `self._decode_bytes(msg.data(), writer_schema)` failed, the error log is still `Failed to get schema info`, which is confusing.

### Modifications

Modify the error message. Even if it failed at
`self._get_writer_schema(topic, version)`, there would still be error logs from the C++ client.