### PR TITLE
Set grpcio minimum version to 1.59.3 so that Alpine py3-grpcio can be used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ extras_require = {}
 extras_require["functions"] = sorted(
     {
       "protobuf>=3.6.1,<=3.20.3",
-      "grpcio>=1.60.0",
+      "grpcio>=1.59.3",
       "apache-bookkeeper-client>=4.16.1",
       "prometheus_client",
       "ratelimit"


### PR DESCRIPTION
### Motivation

When using the Alpine base image in Pulsar, there's a need to compile grpcio from source when 1.60.0 version is required. It's better to allow grpcio version 1.59.3 so that Alpine's py3-grpcio can be used to fulfill the requirement.
Please see https://github.com/apache/pulsar/pull/22613 for more context. 

### Modifications

- downgrade grpcio dependency to 1.59.3

### Additional context

- there's no specific minimum version constraint originating from pulsar-client-python
  - grpcio is required by apache-bookkeeper-client. the dependencies are defined in https://github.com/apache/bookkeeper/blob/master/stream/clients/python/setup.py the version in this file is >= 1.8.2
 - the grpcio minimum version was set to 1.60.0 in this commit: https://github.com/apache/pulsar-client-python/commit/162afd53bda321992223cb209a509ee1c46f870a . The referenced CVE requires 1.53.0 , so there doesn't seem to be any reason why we couldn't downgrade to 1.59.3 .