### PR TITLE
fix: added schema to messages in batch_receive method

### DIFF
--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -1481,6 +1481,7 @@ class Consumer:
         for msg in msgs:
             m = Message()
             m._message = msg
+            m._schema = self._schema
             messages.append(m)
         return messages
 


### PR DESCRIPTION
When consuming from Pulsar in batch, using the "batch_receive" method, the messages didn't include the schema (the added line was missing). By adding that line, it works properly.