### PR TITLE
Fix typos

### DIFF
--- a/pulsar/functions/serde.py
+++ b/pulsar/functions/serde.py
@@ -39,7 +39,7 @@
 """
 SerDe defines the interface for serialization/deserialization.
 
-Everytime a message is read from pulsar topic, the serde is invoked to
+Every time a message is read from pulsar topic, the serde is invoked to
 serialize the bytes into an object before invoking the process method.
 Anytime a python object needs to be written back to pulsar, it is
 serialized into bytes before writing.

--- a/tests/test-conf/standalone-ssl.conf
+++ b/tests/test-conf/standalone-ssl.conf
@@ -121,7 +121,7 @@ acknowledgmentAtBatchIndexLevelEnabled=true
 # Authentication plugin to use when connecting to bookies
 bookkeeperClientAuthenticationPlugin=
 
-# BookKeeper auth plugin implementatation specifics parameters name and values
+# BookKeeper auth plugin implementation specifics parameters name and values
 bookkeeperClientAuthenticationParametersName=
 bookkeeperClientAuthenticationParameters=
 

--- a/tests/test-conf/standalone.conf
+++ b/tests/test-conf/standalone.conf
@@ -109,7 +109,7 @@ acknowledgmentAtBatchIndexLevelEnabled=true
 # Authentication plugin to use when connecting to bookies
 bookkeeperClientAuthenticationPlugin=
 
-# BookKeeper auth plugin implementatation specifics parameters name and values
+# BookKeeper auth plugin implementation specifics parameters name and values
 bookkeeperClientAuthenticationParametersName=
 bookkeeperClientAuthenticationParameters=
 


### PR DESCRIPTION
Found via `codespell -L transaltion`