### PR TITLE
Support seek a MessageId from pulsar module

### DIFF
--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -1576,7 +1576,7 @@ class Consumer:
         """
         self._consumer.redeliver_unacknowledged_messages()
 
-    def seek(self, messageid):
+    def seek(self, messageid: Union[MessageId, _pulsar.MessageId, int]):
         """
         Reset the subscription associated with this consumer to a specific message id or publish timestamp.
         The message id can either be a specific message or represent the first or last messages in the topic.
@@ -1586,10 +1586,10 @@ class Consumer:
         Parameters
         ----------
 
-        messageid:
+        messageid: MessageId, _pulsar.MessageId or int
             The message id for seek, OR an integer event time to seek to
         """
-        self._consumer.seek(messageid)
+        self._consumer.seek(_seek_arg_convert(messageid))
 
     def close(self):
         """
@@ -1745,7 +1745,7 @@ class Reader:
         """
         return self._reader.has_message_available();
 
-    def seek(self, messageid):
+    def seek(self, messageid: Union[MessageId, _pulsar.MessageId, int]):
         """
         Reset this reader to a specific message id or publish timestamp.
         The message id can either be a specific message or represent the first or last messages in the topic.
@@ -1755,10 +1755,10 @@ class Reader:
         Parameters
         ----------
 
-        messageid:
+        messageid: MessageId, _pulsar.MessageId or int
             The message id for seek, OR an integer event time to seek to
         """
-        self._reader.seek(messageid)
+        self._reader.seek(_seek_arg_convert(messageid))
 
     def close(self):
         """
@@ -1829,3 +1829,11 @@ def _listener_wrapper(listener, schema):
         m._schema = schema
         listener(c, m)
     return wrapper
+
+def _seek_arg_convert(seek_arg):
+    if isinstance(seek_arg, MessageId):
+        return seek_arg._msg_id
+    elif isinstance(seek_arg, (_pulsar.MessageId, int)):
+        return seek_arg
+    else:
+        raise ValueError(f"invalid seek_arg type {type(seek_arg)}")

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -1019,10 +1019,21 @@ class PulsarTest(TestCase):
         msg = consumer.receive(TM)
         self.assertEqual(msg.data(), b"hello-0")
 
+        # seek with wrong type
+        with self.assertRaises(ValueError, msg="invalid seek_arg type <class 'float'>"):
+            consumer.seek(1.0)
+
         # seek on messageId
         consumer.seek(ids[50])
         msg = consumer.receive(TM)
         self.assertEqual(msg.data(), b"hello-51")
+
+        # seek on a user provided MessageId
+        msg_id = MessageId(ledger_id=ids[60].ledger_id(),
+                           entry_id=ids[60].entry_id())
+        consumer.seek(msg_id)
+        msg = consumer.receive(TM)
+        self.assertEqual(msg.data(), b"hello-61")
 
         # ditto, but seek on timestamp
         consumer.seek(timestamps[42])
@@ -1033,6 +1044,10 @@ class PulsarTest(TestCase):
         reader = client.create_reader(topic, MessageId.latest)
         with self.assertRaises(pulsar.Timeout):
             reader.read_next(100)
+
+        # seek with wrong type
+        with self.assertRaises(ValueError, msg="invalid seek_arg type <class 'float'>"):
+            consumer.seek(1.0)
 
         # earliest
         reader.seek(MessageId.earliest)
@@ -1047,6 +1062,13 @@ class PulsarTest(TestCase):
         self.assertEqual(msg.data(), b"hello-34")
         msg = reader.read_next(TM)
         self.assertEqual(msg.data(), b"hello-35")
+
+        # seek on a user provided MessageId
+        msg_id = MessageId(ledger_id=ids[44].ledger_id(),
+                           entry_id=ids[44].entry_id())
+        reader.seek(msg_id)
+        msg = reader.read_next(TM)
+        self.assertEqual(msg.data(), b"hello-45")
 
         # seek on timestamp
         reader.seek(timestamps[79])


### PR DESCRIPTION
Currently the `seek` method of `Consumer` or `Reader` can only accept the `MessageId` from the `_pulsar` module, which is the underlying C extension that should not be exposed. If a `MessageId` instance from the `pulsar` module is passed as the argument, this method will fail.