### PR TITLE
Support Python 3.13 and drop the support for Python 3.8

### DIFF
--- a/.github/workflows/ci-build-release-wheels.yaml
+++ b/.github/workflows/ci-build-release-wheels.yaml
@@ -41,11 +41,11 @@ jobs:
           - {name: 'manylinux2014', py_suffix: ''}
           - {name: 'manylinux_musl', py_suffix: '-alpine'}
         python:
-          - {version: '3.8', spec: 'cp38-cp38'}
           - {version: '3.9', spec: 'cp39-cp39'}
           - {version: '3.10', spec: 'cp310-cp310'}
           - {version: '3.11', spec: 'cp311-cp311'}
           - {version: '3.12', spec: 'cp312-cp312'}
+          - {version: '3.13', spec: 'cp313-cp313'}
         cpu:
           - {arch: 'x86_64', platform: 'x86_64'}
           - {arch: 'aarch64', platform: 'arm64'}
@@ -101,11 +101,11 @@ jobs:
       fail-fast: false
       matrix:
         py:
-          - {version: '3.8', version_long:  '3.8.13'}
-          - {version: '3.9', version_long:  '3.9.14'}
-          - {version: '3.10', version_long:  '3.10.7'}
-          - {version: '3.11', version_long:  '3.11.1'}
-          - {version: '3.12', version_long:  '3.12.0'}
+          - {version: '3.9', version_long:  '3.9.20'}
+          - {version: '3.10', version_long:  '3.10.15'}
+          - {version: '3.11', version_long:  '3.11.11'}
+          - {version: '3.12', version_long:  '3.12.8'}
+          - {version: '3.13', version_long:  '3.13.1'}
 
     steps:
       - name: checkout
@@ -131,11 +131,11 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - {version: '3.8'}
           - {version: '3.9'}
           - {version: '3.10'}
           - {version: '3.11'}
           - {version: '3.12'}
+          - {version: '3.13'}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.8', '3.12']
+        version: ['3.9', '3.13']
 
     steps:
       - name: checkout
@@ -115,7 +115,7 @@ jobs:
           - {name: 'manylinux2014', py_suffix: ''}
           - {name: 'manylinux_musl', py_suffix: '-alpine'}
         python:
-          - {version: '3.12', spec: 'cp312-cp312'}
+          - {version: '3.13', spec: 'cp313-cp313'}
         cpu:
           - {arch: 'x86_64', platform: 'x86_64'}
 
@@ -162,7 +162,7 @@ jobs:
     strategy:
       matrix:
         py:
-          - {version: '3.12', version_long:  '3.12.0'}
+          - {version: '3.13', version_long:  '3.13.1'}
 
     steps:
       - name: checkout

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pulsar Python clients support a variety of Pulsar features to enable building ap
 
 ## Requirements
 
-- Python 3.8, 3.9, 3.10, 3.11, 3.12
+- Python 3.9, 3.10, 3.11, 3.12 or 3.13
 - A C++ compiler that supports C++11
 - CMake >= 3.18
 - [Pulsar C++ client library](https://github.com/apache/pulsar-client-cpp)


### PR DESCRIPTION
Python 3.8 reached EOL at Oct.2024. See https://devguide.python.org/versions/