### PR TITLE
Set the minimum macOS version to 13

### DIFF
--- a/.github/workflows/ci-build-release-wheels.yaml
+++ b/.github/workflows/ci-build-release-wheels.yaml
@@ -87,7 +87,7 @@ jobs:
               /pulsar-client-python/pkg/test-wheel.sh
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheel-${{matrix.image.name}}-py${{matrix.python.version}}-${{matrix.cpu.platform}}
           path: wheelhouse/*.whl
@@ -115,7 +115,7 @@ jobs:
         run: pkg/mac/build-mac-wheels.sh ${{matrix.py.version}} ${{matrix.py.version_long}}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheel-mac-py${{matrix.py.version}}
           path: dist/*.whl
@@ -179,7 +179,7 @@ jobs:
           python -c 'import pulsar; c = pulsar.Client("pulsar://localhost:6650"); c.close()'
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheel-windows-py${{matrix.python.version}}
           path: dist/*.whl

--- a/pkg/mac/build-mac-wheels.sh
+++ b/pkg/mac/build-mac-wheels.sh
@@ -52,7 +52,8 @@ fi
 PYTHON_VERSION=$1
 PYTHON_VERSION_LONG=$2
 
-MACOSX_DEPLOYMENT_TARGET=13
+# When building Python from source, it will read this environment variable to determine the minimum supported macOS version
+export MACOSX_DEPLOYMENT_TARGET=13
 pushd $CACHE_DIR
 
 # We need to build OpenSSL from source to have universal2 binaries
@@ -99,8 +100,8 @@ if [ ! -f Python-${PYTHON_VERSION_LONG}/.done ]; then
     tar xfz Python-${PYTHON_VERSION_LONG}.tgz
 
     pushd Python-${PYTHON_VERSION_LONG}
-        CFLAGS="-fPIC -O3 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
-            ./configure --prefix=$PREFIX --enable-shared --enable-universalsdk --with-universal-archs=universal2 --with-openssl=$PREFIX
+        export CFLAGS="-fPIC -O3"
+        ./configure --prefix=$PREFIX --enable-shared --enable-universalsdk --with-universal-archs=universal2 --with-openssl=$PREFIX
         make -j16
         make install
 

--- a/pkg/mac/build-mac-wheels.sh
+++ b/pkg/mac/build-mac-wheels.sh
@@ -99,7 +99,8 @@ if [ ! -f Python-${PYTHON_VERSION_LONG}/.done ]; then
     tar xfz Python-${PYTHON_VERSION_LONG}.tgz
 
     pushd Python-${PYTHON_VERSION_LONG}
-        ./configure --prefix=$PREFIX --enable-shared --enable-universalsdk --with-universal-archs=universal2 --with-openssl=$PREFIX
+        CFLAGS="-fPIC -O3 -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
+            ./configure --prefix=$PREFIX --enable-shared --enable-universalsdk --with-universal-archs=universal2 --with-openssl=$PREFIX
         make -j16
         make install
 


### PR DESCRIPTION
Currently the build workflow for macOS wheels run on macos-14 runner so that the wheel's target macOS version is 14. This is because the `-mmacosx-version-min` option is not specified when building Python from source.

You can find the following log in https://github.com/apache/pulsar-client-python/actions/runs/12878584451/job/35904753892

```
checking which MACOSX_DEPLOYMENT_TARGET to use... 14.7
```

We need to add `MACOSX_DEPLOYMENT_TARGET` as the environment variable, see https://github.com/python/cpython/blob/ec91e1c2762412f1408b0dfb5d281873b852affe/configure#L10759

Here we set it with 13 because 13 is the current minimum maintained version, see https://en.wikipedia.org/wiki/MacOS_version_history