### PR TITLE
Fix conflicts with other python libraries due to static link to libgcc and libstdc++

### DIFF
--- a/pkg/build-wheel-inside-docker.sh
+++ b/pkg/build-wheel-inside-docker.sh
@@ -21,6 +21,7 @@
 set -e -x
 
 cd /pulsar-client-python
+ROOT_DIR=$PWD
 source build-support/dep-url.sh
 
 # Build cpp wheels
@@ -46,6 +47,9 @@ if [ $CPP_BINARY_TYPE == "rpm" ]; then
     cd ..
     ./bootstrap-vcpkg.sh
     cd ..
+    if [ $PULSAR_CPP_VERSION == "3.7.0" ]; then
+        patch lib/CMakeLists.txt $ROOT_DIR/pkg/manylinux2014/pulsar-client-cpp-3.7.0.patch
+    fi
     cmake -B build-cpp -DINTEGRATE_VCPKG=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF -DBUILD_DYNAMIC_LIB=ON -DBUILD_STATIC_LIB=ON
     cmake --build build-cpp -j8 --target install
     cd ..

--- a/pkg/manylinux2014/pulsar-client-cpp-3.7.0.patch
+++ b/pkg/manylinux2014/pulsar-client-cpp-3.7.0.patch
@@ -1,0 +1,13 @@
+--- lib/CMakeLists.txt
++++ lib/CMakeLists.txt
+@@ -93,10 +93,6 @@
+     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+         target_link_options(pulsarShared PRIVATE -Wl,-Bsymbolic)
+     endif ()
+-    check_cxx_symbol_exists(__GLIBCXX__ iostream GLIBCXX)
+-    if (GLIBCXX)
+-        target_link_libraries(pulsarShared PUBLIC -static-libgcc -static-libstdc++)
+-    endif ()
+ endif()
+
+ check_cxx_symbol_exists(getauxval sys/auxv.h HAVE_AUXV_GETAUXVAL)


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-python/issues/242
Fixes https://github.com/apache/pulsar-client-python/issues/243
Fixes https://github.com/apache/pulsar-client-python/issues/245

Add a patch to avoid linking to libgcc and libstdc++.