### PR TITLE
add stats_interval_in_seconds parameter to the client configuration

### DIFF
--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -482,6 +482,7 @@ class Client:
                  message_listener_threads=1,
                  concurrent_lookup_requests=50000,
                  log_conf_file_path=None,
+                 stats_interval_in_seconds=600,
                  use_tls=False,
                  tls_trust_certs_file_path=None,
                  tls_allow_insecure_connection=False,
@@ -520,6 +521,9 @@ class Client:
         log_conf_file_path: str, optional
             This parameter is deprecated and makes no effect. It's retained only for compatibility.
             Use `logger` to customize a logger.
+        stats_interval_in_seconds: int, default=600
+            Set the interval between each stats information update. Stats are printed and/or
+            passed to the statistics listener at this interval. Set to 0 to disable stats collection.
         use_tls: bool, default=False
             Configure whether to use TLS encryption on the connection. This setting is deprecated.
             TLS will be automatically enabled if the ``serviceUrl`` is set to ``pulsar+ssl://`` or ``https://``
@@ -560,6 +564,7 @@ class Client:
         _check_type(int, message_listener_threads, 'message_listener_threads')
         _check_type(int, concurrent_lookup_requests, 'concurrent_lookup_requests')
         _check_type_or_none(str, log_conf_file_path, 'log_conf_file_path')
+        _check_type(int, stats_interval_in_seconds, 'stats_interval_in_seconds')
         _check_type(bool, use_tls, 'use_tls')
         _check_type_or_none(str, tls_trust_certs_file_path, 'tls_trust_certs_file_path')
         _check_type(bool, tls_allow_insecure_connection, 'tls_allow_insecure_connection')
@@ -574,6 +579,7 @@ class Client:
         conf.io_threads(io_threads)
         conf.message_listener_threads(message_listener_threads)
         conf.concurrent_lookup_requests(concurrent_lookup_requests)
+        conf.stats_interval_in_seconds(stats_interval_in_seconds)
 
         if isinstance(logger, logging.Logger):
             conf.set_logger(self._prepare_logger(logger))

--- a/src/config.cc
+++ b/src/config.cc
@@ -157,6 +157,9 @@ void export_config(py::module_& m) {
         .def("concurrent_lookup_requests", &ClientConfiguration::getConcurrentLookupRequest)
         .def("concurrent_lookup_requests", &ClientConfiguration::setConcurrentLookupRequest,
              return_value_policy::reference)
+        .def("stats_interval_in_seconds", &ClientConfiguration::getStatsIntervalInSeconds)
+        .def("stats_interval_in_seconds", &ClientConfiguration::setStatsIntervalInSeconds,
+             return_value_policy::reference)
         .def("use_tls", &ClientConfiguration::isUseTls)
         .def("use_tls", &ClientConfiguration::setUseTls, return_value_policy::reference)
         .def("tls_trust_certs_file_path", &ClientConfiguration::getTlsTrustCertsFilePath,

--- a/tests/pulsar_test.py
+++ b/tests/pulsar_test.py
@@ -828,6 +828,7 @@ class PulsarTest(TestCase):
         self._check_value_error(lambda: Client(None))
         self._check_value_error(lambda: Client(self.serviceUrl, authentication="test"))
         self._check_value_error(lambda: Client(self.serviceUrl, operation_timeout_seconds="test"))
+        self._check_value_error(lambda: Client(self.serviceUrl, stats_interval_in_seconds="test"))
         self._check_value_error(lambda: Client(self.serviceUrl, io_threads="test"))
         self._check_value_error(lambda: Client(self.serviceUrl, message_listener_threads="test"))
         self._check_value_error(lambda: Client(self.serviceUrl, concurrent_lookup_requests="test"))


### PR DESCRIPTION
With this PR, we will be able to control the printed stats.
The default interval (600 seconds) excessively prints stats when you have thousands of clients.

We have this feature on [Java client](https://stackoverflow.com/questions/75819534/how-to-disable-client-statistic-message-when-using-python-pulsar-client) and I wanted to add it for Python.