### PR TITLE
Remove version upper bound for protobuf dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ extras_require = {}
 # functions dependencies
 extras_require["functions"] = sorted(
     {
-      "protobuf>=3.6.1,<=3.20.3",
+      "protobuf>=3.6.1",
       "grpcio>=1.59.3",
       "apache-bookkeeper-client>=4.16.1",
       "prometheus_client",


### PR DESCRIPTION
We are limiting the max protobuf version to 3.20.3, though this version is very old and now has a reported vulnerability: https://avd.aquasec.com/nvd/2025/cve-2025-4565/