### PR TITLE
fix(asyncio): Avoid InvalidStateError on late callbacks after cancel

### DIFF
--- a/pulsar/asyncio.py
+++ b/pulsar/asyncio.py
@@ -828,6 +828,8 @@ class Client:
 
 def _set_future(future: asyncio.Future, result: _pulsar.Result, value: Any):
     def complete():
+        if future.done():
+            return
         if result == _pulsar.Result.Ok:
             future.set_result(value)
         else:

--- a/tests/asyncio_test.py
+++ b/tests/asyncio_test.py
@@ -39,6 +39,7 @@ from pulsar.asyncio import (  # pylint: disable=import-error
     Consumer,
     Producer,
     PulsarException,
+    _set_future,
 )
 from pulsar.schema import (  # pylint: disable=import-error
     AvroSchema,
@@ -482,6 +483,26 @@ class AsyncioTest(IsolatedAsyncioTestCase):
         self.assertIsInstance(msg.value(), ExampleRecord)
         self.assertEqual(msg.value().str_field, 'test')
         self.assertEqual(msg.value().int_field, 42)
+
+
+class AsyncioSetFutureTest(IsolatedAsyncioTestCase):
+    """Tests for asyncio bridge helpers (no live Pulsar broker)."""
+
+    async def test_set_future_noop_when_future_cancelled(self):
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        fut.cancel()
+        _set_future(fut, _pulsar.Result.Ok, None)
+        await asyncio.sleep(0)
+        self.assertTrue(fut.cancelled())
+
+    async def test_set_future_noop_when_future_already_resolved(self):
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        fut.set_result("first")
+        _set_future(fut, _pulsar.Result.Ok, "late")
+        await asyncio.sleep(0)
+        self.assertEqual(fut.result(), "first")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Summary
Guard `_set_future` so scheduled completions are skipped when the `asyncio Future` is cancelled.

# Problem
`_set_future` schedules `complete()` via `call_soon_threadsafe`. If the `Future` is cancelled, a late callback could still call `set_result` / `set_exception`, which raises `asyncio.InvalidStateError` and is logged as an exception in the event loop callback.

# Solution
At the start of `complete()`, return early if `future.done()`. This matches common `asyncio` callback bridges (no-op when the future is no longer pending).

# Testing
Added `AsyncioSetFutureTest` with two cases (no live broker): cancelled `Future` + late success callback, and already-resolved `Future` + late callback.