### PR TITLE
Fix release workflow and scripts

### DIFF
--- a/.github/workflows/ci-build-release-wheels.yaml
+++ b/.github/workflows/ci-build-release-wheels.yaml
@@ -32,7 +32,7 @@ jobs:
   linux-wheel:
     name: Wheel ${{matrix.image.name}} - Py ${{matrix.python.version}} - ${{matrix.cpu.platform}}
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 360
 
     strategy:
       fail-fast: false
@@ -95,7 +95,7 @@ jobs:
   mac-wheels:
     name: Wheel MacOS Universal2 - Py ${{matrix.py.version}}
     runs-on: macos-14
-    timeout-minutes: 300
+    timeout-minutes: 360
 
     strategy:
       fail-fast: false
@@ -125,7 +125,7 @@ jobs:
     runs-on: windows-2022
     env:
       PULSAR_CPP_DIR: 'C:\\pulsar-cpp'
-    timeout-minutes: 300
+    timeout-minutes: 360
 
     strategy:
       fail-fast: false

--- a/build-support/stage-release.sh
+++ b/build-support/stage-release.sh
@@ -42,9 +42,11 @@ mv $TAG.tar.gz pulsar-client-python-$VERSION.tar.gz
 
 # Download the Python wheels
 URLS=$(curl -L https://api.github.com/repos/apache/pulsar-client-python/actions/runs/$WORKFLOW_ID/artifacts \
-  | jq '.artifacts[] .archive_download_url' | sed 's/^"\(.*\)"$/\1/')
+  | jq -r '.artifacts[]
+      | select(((.name // "") | contains("dockerbuild")) | not)
+      | .archive_download_url')
 for URL in $URLS; do
-    curl -O -L $URL -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN"
+    curl -O -L "$URL" -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN"
     unzip -q zip
     rm -f zip
 done


### PR DESCRIPTION
1. Extend the build time to 6 hours because now it spends more time to build on arm due to extra abseil dependency from C++ client
2. Fix the download script to filter out artifacts whose name contains "dockerbuild"

Check https://github.com/apache/pulsar-client-python/actions/runs/25722329950 for example